### PR TITLE
Make BufferedRecord generic to support flexible record types

### DIFF
--- a/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
+++ b/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
@@ -28,8 +28,8 @@ public class ResequenceTopologyConfig {
     }
 
     @Bean
-    public Serde<List<BufferedRecord>> bufferedRecordListSerde() {
-        return new BufferedRecordListSerde();
+    public Serde<List<BufferedRecord<SampleRecord>>> bufferedRecordListSerde() {
+        return new BufferedRecordListSerde<>(SampleRecord.class);
     }
 
     @Bean
@@ -38,8 +38,8 @@ public class ResequenceTopologyConfig {
             @Value("${app.pipeline.sink.topic}") String sinkTopic,
             StreamsBuilder builder,
             Serde<SampleRecord> sampleRecordSerde,
-            Serde<List<BufferedRecord>> bufferedRecordListSerde,
-            Comparator<BufferedRecord> resequenceComparator) {
+            Serde<List<BufferedRecord<SampleRecord>>> bufferedRecordListSerde,
+            Comparator<BufferedRecord<SampleRecord>> resequenceComparator) {
 
         Topology topology = builder.build();
 

--- a/sample-app/src/main/java/com/example/sampleapp/domain/BufferedRecord.java
+++ b/sample-app/src/main/java/com/example/sampleapp/domain/BufferedRecord.java
@@ -9,9 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-// TODO: BufferedRecord#record should be a generic type <T> for flexibility
-public class BufferedRecord {
-    private SampleRecord record;
+public class BufferedRecord<T> {
+    private T record;
     private int partition;
     private long offset;
     private long timestamp;

--- a/sample-app/src/main/java/com/example/sampleapp/domain/ResequenceComparator.java
+++ b/sample-app/src/main/java/com/example/sampleapp/domain/ResequenceComparator.java
@@ -6,7 +6,7 @@ import java.util.Comparator;
 import java.util.Map;
 
 @Component
-public class ResequenceComparator implements Comparator<BufferedRecord> {
+public class ResequenceComparator implements Comparator<BufferedRecord<SampleRecord>> {
 
     // Define order: CREATE (0) < UPDATE (1) < DELETE (2)
     // Note: User prompt said "CREATE > UPDATE > DELETE", but context implies sort
@@ -18,7 +18,7 @@ public class ResequenceComparator implements Comparator<BufferedRecord> {
             "DELETE", 2);
 
     @Override
-    public int compare(BufferedRecord o1, BufferedRecord o2) {
+    public int compare(BufferedRecord<SampleRecord> o1, BufferedRecord<SampleRecord> o2) {
         SampleRecord r1 = o1.getRecord();
         SampleRecord r2 = o2.getRecord();
 


### PR DESCRIPTION
## Summary
Converts `BufferedRecord` from a `SampleRecord`-specific wrapper to a generic type `BufferedRecord<T>`, enabling the resequencer to work with any domain type. This is a critical foundational change for making the `resequence-starter` module truly reusable as a library.

## Changes

### Core Type Changes
- **BufferedRecord.java**: Added type parameter `<T>` to make the `record` field generic instead of hardcoded to `SampleRecord`
- **ResequenceComparator.java**: Updated to `Comparator<BufferedRecord<SampleRecord>>` since it needs to access `SampleRecord`-specific fields
- **BufferedRecordListSerde.java**: Made generic `BufferedRecordListSerde<T>` with Jackson `JavaType` support for proper deserialization
- **ResequenceProcessor.java**: Updated all `BufferedRecord` references to use `BufferedRecord<SampleRecord>`
- **ResequenceTopologyConfig.java**: Updated bean definitions to pass `SampleRecord.class` to the generic serde

### Key Implementation Details
1. The serde now accepts a `Class<T>` parameter to construct the proper Jackson `JavaType` for deserialization
2. All type parameters are explicitly specified to maintain type safety
3. The sample-app continues to use `BufferedRecord<SampleRecord>`, but the class itself is now reusable

## Testing
- ✅ All existing tests pass without modification
- ✅ Full build successful: `./gradlew clean build`
- ✅ `ResequenceComparatorSpec` tests pass, validating the ordering logic still works correctly

## Why This Matters
When we move the core resequencing logic into the `resequence-starter` module:
- Users can buffer and resequence their own domain types
- No need to fork or modify the library code
- The library becomes truly generic and reusable
- Supports the vision of `sample-app` being just an example implementation

## Related Issues
Resolves #3

## Next Steps
This change is a prerequisite for:
- Moving `BufferedRecord` to the `resequence-starter` module
- Making other components generic (processor, comparator interfaces)
- Addressing issues #7, #8, #9 (key mapping, non-String keys, value mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)