### PR TITLE
Make state store name configurable via application.yml

### DIFF
--- a/sample-app/src/main/java/com/example/sampleapp/processor/ResequenceProcessor.java
+++ b/sample-app/src/main/java/com/example/sampleapp/processor/ResequenceProcessor.java
@@ -18,17 +18,18 @@ import java.util.List;
 public class ResequenceProcessor extends ContextualProcessor<Long, SampleRecord, String, SampleRecord> {
 
     private final Comparator<BufferedRecord<SampleRecord>> comparator;
+    private final String stateStoreName;
     private KeyValueStore<Long, List<BufferedRecord<SampleRecord>>> store;
 
-    public ResequenceProcessor(Comparator<BufferedRecord<SampleRecord>> comparator) {
+    public ResequenceProcessor(Comparator<BufferedRecord<SampleRecord>> comparator, String stateStoreName) {
         this.comparator = comparator;
+        this.stateStoreName = stateStoreName;
     }
 
     @Override
     public void init(ProcessorContext<String, SampleRecord> context) {
         super.init(context);
-        // TODO: Make state store name configurable in application yml
-        this.store = context.getStateStore("resequence-buffer");
+        this.store = context.getStateStore(stateStoreName);
 
         // Schedule punctuator to flush buffered records every 2 seconds (wall-clock time)
         // TODO: Make duration configurable in application yml

--- a/sample-app/src/main/resources/application.yml
+++ b/sample-app/src/main/resources/application.yml
@@ -16,6 +16,9 @@ app:
     sink:
       topic: ${app.pipeline.source.topic}-resequenced
 
+resequence:
+  state-store-name: resequence-buffer
+
 logging:
   level:
     com.example.sampleapp: INFO


### PR DESCRIPTION
## Summary
- Adds `resequence.state-store-name` configuration property to `application.yml`
- Removes hardcoded "resequence-buffer" from `ResequenceProcessor` and `ResequenceTopologyConfig`
- State store name is now injected via constructor to `ResequenceProcessor`

## Benefits
- Supports multiple resequencing processors with different state stores
- Allows organizations to follow their naming conventions
- Makes the library more flexible for different use cases

## Changes
- `application.yml`: Added `resequence.state-store-name: resequence-buffer`
- `ResequenceProcessor.java`: Accept state store name via constructor, removed hardcoded value
- `ResequenceTopologyConfig.java`: Inject state store name from configuration

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] Default configuration maintains backward compatibility

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)