### PR TITLE
Inject auto-configured JsonMapper into BufferedRecordListSerde

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 dependencies {
     implementation(project(":resequence-starter"))
 implementation("org.springframework.boot:spring-boot-starter-kafka")
+    implementation("org.springframework.boot:spring-boot-starter-json")
     implementation("org.apache.kafka:kafka-streams")
-    implementation("tools.jackson.core:jackson-databind")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
+++ b/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
@@ -13,6 +13,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.state.Stores;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
@@ -20,6 +21,7 @@ import org.springframework.kafka.support.serializer.JacksonJsonSerde;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 @Configuration
@@ -33,8 +35,9 @@ public class ResequenceTopologyConfig {
     }
 
     @Bean
-    public Serde<List<BufferedRecord<SampleRecord>>> bufferedRecordListSerde() {
-        return new BufferedRecordListSerde<>(SampleRecord.class);
+    public Serde<List<BufferedRecord<SampleRecord>>> bufferedRecordListSerde(JsonMapper objectMapper) {
+        Objects.requireNonNull(objectMapper, "ObjectMapper must not be null");
+        return new BufferedRecordListSerde<>(SampleRecord.class, objectMapper);
     }
 
     @Bean

--- a/sample-app/src/main/java/com/example/sampleapp/serde/BufferedRecordListSerde.java
+++ b/sample-app/src/main/java/com/example/sampleapp/serde/BufferedRecordListSerde.java
@@ -1,8 +1,8 @@
 package com.example.sampleapp.serde;
 
 import com.example.sampleapp.domain.BufferedRecord;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
@@ -15,8 +15,8 @@ public class BufferedRecordListSerde<T> implements Serde<List<BufferedRecord<T>>
     private final ObjectMapper mapper;
     private final JavaType javaType;
 
-    public BufferedRecordListSerde(Class<T> recordType) {
-        this.mapper = new ObjectMapper();
+    public BufferedRecordListSerde(Class<T> recordType, ObjectMapper mapper) {
+        this.mapper = mapper;
         this.javaType = mapper.getTypeFactory().constructCollectionType(
                 List.class,
                 mapper.getTypeFactory().constructParametricType(BufferedRecord.class, recordType)

--- a/sample-app/src/test/groovy/com/example/sampleapp/processor/ResequenceProcessorSpec.groovy
+++ b/sample-app/src/test/groovy/com/example/sampleapp/processor/ResequenceProcessorSpec.groovy
@@ -8,6 +8,7 @@ import com.example.sampleapp.domain.SampleRecord
 import com.example.sampleapp.serde.BufferedRecordListSerde
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsConfig
+import tools.jackson.databind.json.JsonMapper
 import org.apache.kafka.streams.TestInputTopic
 import org.apache.kafka.streams.TestOutputTopic
 import org.apache.kafka.streams.Topology
@@ -56,7 +57,7 @@ class ResequenceProcessorSpec extends Specification {
             java.util.function.BiConsumer<KR, SampleRecord> valueEnricher) {
 
         def valueSerde = new JacksonJsonSerde<>(SampleRecord)
-        def bufferedSerde = new BufferedRecordListSerde<>(SampleRecord)
+        def bufferedSerde = new BufferedRecordListSerde<>(SampleRecord, JsonMapper.builder().build())
 
         def topology = new Topology()
         topology.addStateStore(Stores.keyValueStoreBuilder(


### PR DESCRIPTION
## Summary

- Adds `spring-boot-starter-json` to pull in Spring Boot 4's `JacksonAutoConfiguration`, which registers a `JsonMapper` bean (Jackson 3 native)
- Updates `BufferedRecordListSerde` constructor to accept an injected `ObjectMapper` instead of instantiating one internally
- Updates `ResequenceTopologyConfig.bufferedRecordListSerde` to receive the Spring-managed `JsonMapper` with a non-null guard
- Migrates `BufferedRecordListSerde` imports from `com.fasterxml.jackson` to `tools.jackson` (Jackson 3)
- Updates `ResequenceProcessorSpec` to use `JsonMapper.builder().build()` to match production behavior

Fixes #14

## Test plan

- [x] All existing tests pass (`./gradlew :sample-app:test`)
- [x] `OutOfOrderSpec` integration tests verify end-to-end resequencing still works with the injected mapper
- [x] `ResequenceProcessorSpec` unit tests verify processor behavior with a `JsonMapper` instance matching production

🤖 Generated with [Claude Code](https://claude.com/claude-code)