### PR TITLE
Harden BufferedRecordListSerde exception handling

### DIFF
--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/serde/BufferedRecordListSerde.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/serde/BufferedRecordListSerde.java
@@ -1,6 +1,7 @@
 package com.snekse.kafka.streams.resequence.serde;
 
 import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
+import org.apache.kafka.common.errors.SerializationException;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -30,7 +31,10 @@ public class BufferedRecordListSerde<T> implements Serde<List<BufferedRecord<T>>
             try {
                 return mapper.writeValueAsBytes(data);
             } catch (Exception e) {
-                throw new RuntimeException("Failed to serialize list", e);
+                throw new SerializationException(
+                        "Failed to serialize buffered record list for topic '" + topic + "'",
+                        e
+                );
             }
         };
     }
@@ -42,7 +46,10 @@ public class BufferedRecordListSerde<T> implements Serde<List<BufferedRecord<T>>
             try {
                 return mapper.readValue(data, javaType);
             } catch (Exception e) {
-                throw new RuntimeException("Failed to deserialize list", e);
+                throw new SerializationException(
+                        "Failed to deserialize buffered record list for topic '" + topic + "'",
+                        e
+                );
             }
         };
     }

--- a/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/serde/BufferedRecordListSerdeSpec.groovy
+++ b/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/serde/BufferedRecordListSerdeSpec.groovy
@@ -1,6 +1,7 @@
 package com.snekse.kafka.streams.resequence.serde
 
 import com.snekse.kafka.streams.resequence.domain.BufferedRecord
+import org.apache.kafka.common.errors.SerializationException
 import tools.jackson.databind.json.JsonMapper
 import spock.lang.Specification
 
@@ -50,5 +51,34 @@ class BufferedRecordListSerdeSpec extends Specification {
     def 'should deserialize null to empty list'() {
         expect:
         serde.deserializer().deserialize('test-topic', null) == []
+    }
+
+    def 'should throw SerializationException with topic details when serialization fails'() {
+        given:
+        def objectSerde = new BufferedRecordListSerde<>(Object, mapper)
+        def records = [
+            BufferedRecord.<Object>builder()
+                .record(new Object())
+                .partition(0)
+                .offset(10L)
+                .timestamp(1000L)
+                .build()
+        ]
+
+        when:
+        objectSerde.serializer().serialize('failing-topic', records)
+
+        then:
+        def ex = thrown(SerializationException)
+        ex.message == "Failed to serialize buffered record list for topic 'failing-topic'"
+    }
+
+    def 'should throw SerializationException with topic details when deserialization fails'() {
+        when:
+        serde.deserializer().deserialize('broken-topic', 'not-json'.bytes)
+
+        then:
+        def ex = thrown(SerializationException)
+        ex.message == "Failed to deserialize buffered record list for topic 'broken-topic'"
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the generic `RuntimeException` thrown from the buffered record serde with Kafka-native `SerializationException` and include the Kafka topic in the error message to improve diagnostics and production operability.

### Description
- `BufferedRecordListSerde` now throws `org.apache.kafka.common.errors.SerializationException` with topic-aware messages for both serializer and deserializer failure paths, and `BufferedRecordListSerdeSpec` was extended to assert these failure behaviors.

### Testing
- Attempted to run `./gradlew :resequence-starter:test --tests com.snekse.kafka.streams.resequence.serde.BufferedRecordListSerdeSpec`, but the build failed before tests executed due to a Gradle/Kotlin Java version parsing error (`java.lang.IllegalArgumentException: 25.0.1`), so the new tests could not be run successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87a49665483238dafde40126023f3)