### PR TITLE
Add observability: ResequenceEventListener + OTel integration

### DIFF
--- a/docs/ideation/resequence-observability/contract.md
+++ b/docs/ideation/resequence-observability/contract.md
@@ -1,0 +1,91 @@
+# Resequence Observability Contract
+
+**Created**: 2026-03-04
+**Confidence Score**: 96/100
+**Status**: Draft
+
+## Problem Statement
+
+The `resequence-starter` library has no observability surface. Users cannot see how many records are buffered, how long flushes take, or whether records are being silently dropped due to null keys. This makes it difficult to operate the resequencer in production — problems like buffer growth, flush latency spikes, or data quality issues are invisible without external tooling.
+
+Library users (particularly on Confluent Platform) may already have Kafka Streams infrastructure metrics via the OTel Java agent or JMX, but those metrics don't surface resequencer-specific business events: buffer depth per key, records sorted and forwarded per flush, or null-key drops. There is no hook for users who want to wire in their own observability backend.
+
+Without an observability surface, users have no way to verify the resequencer is behaving correctly in production, tune flush intervals based on real data, or detect data quality issues early.
+
+## Goals
+
+1. Add a `ResequenceEventListener` interface to `resequence-starter` with callbacks for all significant processing events, with a no-op default so existing users are unaffected.
+2. Add `opentelemetry-api` as a `compileOnly` dependency and provide an `OtelResequenceEventListener` implementation that emits counters, gauges, and histograms — active when the OTel API is on the runtime classpath.
+3. Wire the listener into `ResequenceProcessor` via constructor (framework-agnostic) and via Spring auto-configuration (Spring Boot users get automatic wiring).
+4. Update `sample-app` to demonstrate the OTel listener in action and log an accumulated metrics summary on application shutdown.
+
+## Success Criteria
+
+- [ ] `ResequenceEventListener` interface exists with callbacks: `onRecordBuffered`, `onFlushStarted(isFullScan)`, `onFlushCompleted(keysCount, recordsCount)`, `onKeyFlushed(key, recordCount)`, `onNullKeyDropped`
+- [ ] A static `ResequenceEventListener.noOp()` factory exists; `ResequenceProcessor` defaults to it when no listener is provided
+- [ ] `ResequenceProcessor` accepts a `ResequenceEventListener` as a constructor parameter (backward-compatible — existing constructors continue to work)
+- [ ] `OtelResequenceEventListener` implements `ResequenceEventListener` using `opentelemetry-api` instruments: counter for records buffered, counter for records forwarded, counter for null-key drops, histogram for flush duration, gauge for buffer depth at flush time
+- [ ] `ResequenceAutoConfiguration` registers an `OtelResequenceEventListener` bean when `opentelemetry-api` is on the classpath and `resequence.otel.enabled` is not `false`; falls back to no-op otherwise
+- [ ] `@ConditionalOnMissingBean(ResequenceEventListener.class)` ensures user-provided beans take precedence
+- [ ] `resequence.otel.enabled=false` disables OTel auto-configuration
+- [ ] `sample-app` wires the listener and logs metric totals on `ContextClosedEvent`
+- [ ] `OtelResequenceEventListener` is verified via Spock tests using OTel's `InMemoryMetricReader` (`opentelemetry-sdk-testing` test dependency): assert counter values, gauge readings, and histogram recordings after running processor operations through `TopologyTestDriver`
+- [ ] Existing `ResequenceProcessorSpec` tests continue to pass without modification
+- [ ] `resequence-starter` build compiles cleanly without OTel SDK on the runtime classpath
+- [ ] `sample-app` can be started via `./gradlew :sample-app:bootRun` and the console shows accumulated metric totals logged on shutdown (records buffered, records forwarded, null keys dropped, flush count)
+
+## Scope Boundaries
+
+### In Scope
+
+- `ResequenceEventListener` interface and `noOp()` implementation in `resequence-starter`
+- `OtelResequenceEventListener` using `opentelemetry-api` (`compileOnly`) in `resequence-starter`
+- Updated `ResequenceProcessor` constructors accepting a listener
+- Updated `ResequenceAutoConfiguration` with OTel conditional bean registration and `resequence.otel.enabled` property
+- Updated `ResequenceProperties` to include `otel.enabled` flag
+- `sample-app` wiring: OTel SDK dependency, listener bean, shutdown logging via `ApplicationListener<ContextClosedEvent>`
+- Spock tests for the listener interface and OTel listener (with a mock/test OTel SDK)
+
+### Out of Scope
+
+- Micrometer integration — OTel is the chosen mechanism; Micrometer bridge is a future consideration
+- OpenTelemetry tracing / spans — only metrics (counters, gauges, histograms); traces deferred
+- A separate `resequence-starter-otel` module — `compileOnly` in core keeps it simple for now
+- Exposing metrics via Spring Boot Actuator in sample-app — shutdown log summary is sufficient
+- Confluent-specific metric forwarding — covered by platform-level OTel agent
+
+### Future Considerations
+
+- Composite listener (allow multiple listeners to be chained)
+- Micrometer bridge module for users who prefer Micrometer over OTel directly
+- OTel tracing: wrap flush cycle as a span for distributed trace context
+- Per-partition metric dimensions (if multi-partition use cases emerge)
+
+## Execution Plan
+
+_Added during Phase 5 handoff. Pick up this contract cold and know exactly how to execute._
+
+### Dependency Graph
+
+```
+Phase 1: ResequenceEventListener interface + processor wiring
+  └── Phase 2: OTel implementation + auto-configuration + sample-app
+```
+
+### Execution Steps
+
+**Strategy**: Sequential
+
+1. **Phase 1** — Listener interface and processor wiring _(blocking)_
+   ```bash
+   /execute-spec docs/ideation/resequence-observability/spec-phase-1.md
+   ```
+
+2. **Phase 2** — OTel implementation, auto-config, and sample-app _(blocked by Phase 1)_
+   ```bash
+   /execute-spec docs/ideation/resequence-observability/spec-phase-2.md
+   ```
+
+---
+
+_This contract was generated from brain dump input. Review and approve before proceeding to specification._

--- a/docs/ideation/resequence-observability/spec-phase-1.md
+++ b/docs/ideation/resequence-observability/spec-phase-1.md
@@ -1,0 +1,456 @@
+# Implementation Spec: Resequence Observability - Phase 1
+
+**Contract**: ./contract.md
+**Estimated Effort**: S
+
+## Technical Approach
+
+Add a `ResequenceEventListener` interface to the `resequence-starter` module. The interface defines callbacks for every significant processing event inside `ResequenceProcessor`. A static `noOp()` factory returns a no-allocation, do-nothing implementation so that the processor's default behavior is unchanged.
+
+Update `ResequenceProcessor` to accept a `ResequenceEventListener` as an optional constructor parameter. The two existing constructors are preserved exactly (backward-compatible) and internally chain to a new three-arg-plus-listener overload that defaults to `noOp()`. Listener calls are inserted at each meaningful event point in the processor.
+
+No new dependencies are introduced in this phase. The only new source files are the interface and its test spec.
+
+## Feedback Strategy
+
+**Inner-loop command**: `./gradlew :resequence-starter:test`
+
+**Playground**: Test suite via `TopologyTestDriver` (same pattern as `ResequenceProcessorSpec`).
+
+**Why this approach**: Changes are entirely in processor logic; the existing test driver setup is already fast and exercises the full event flow.
+
+## File Changes
+
+### New Files
+
+| File Path | Purpose |
+| --- | --- |
+| `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/ResequenceEventListener.java` | Listener interface with 5 callbacks and a `noOp()` factory |
+| `resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/ResequenceEventListenerSpec.groovy` | Spock spec verifying each listener callback fires with correct arguments |
+
+### Modified Files
+
+| File Path | Changes |
+| --- | --- |
+| `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/processor/ResequenceProcessor.java` | Add `listener` field; add new constructor overload; insert `listener.on*()` calls at 5 event points |
+
+## Implementation Details
+
+### ResequenceEventListener Interface
+
+**Pattern to follow**: `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/processor/ValueMapper.java` (functional interface with static factory)
+
+**Overview**: Defines the observability surface for the processor. Uses `Object` for the key type to avoid making the interface generic — the listener is for observation only, not type-safe processing.
+
+**Javadoc requirement**: Every method on the interface must have a full Javadoc comment explaining: (1) when the callback fires, (2) what each parameter means, and (3) any ordering guarantees (e.g., "called before the key is deleted from the state store"). This is a public API surface — treat the Javadocs as user-facing documentation. The class-level Javadoc should describe the intended use cases (observability, metrics, custom business logic) and note that implementations must be thread-safe if the processor is used in multi-threaded contexts (though KStreams processors are single-threaded per task).
+
+```java
+package com.snekse.kafka.streams.resequence.listener;
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
+
+/**
+ * Callback interface for observing significant events in a {@link com.snekse.kafka.streams.resequence.processor.ResequenceProcessor}.
+ *
+ * <p>Implementations can use this interface to collect metrics, emit telemetry, log diagnostic
+ * information, or trigger custom business logic in response to resequencing events. A no-op
+ * implementation is available via {@link #noOp()}.
+ *
+ * <p>Callback methods are invoked synchronously on the Kafka Streams processor thread.
+ * Because Kafka Streams tasks are single-threaded, implementations do not need to be
+ * thread-safe unless a single listener instance is shared across multiple processor instances.
+ *
+ * <p>Implementations should be lightweight and non-blocking. Expensive operations (e.g., remote
+ * calls) should be performed asynchronously to avoid introducing latency into the processing loop.
+ */
+public interface ResequenceEventListener {
+
+    /**
+     * Called when a record has been appended to the resequence buffer for the given key.
+     *
+     * <p>This callback fires after the record is successfully written to the state store.
+     * It is not called for records with null keys (see {@link #onNullKeyDropped()}).
+     *
+     * @param key    the record's input key (before any key mapping)
+     * @param record the buffered record, including the original value and Kafka metadata
+     *               (partition, offset, timestamp)
+     */
+    void onRecordBuffered(Object key, BufferedRecord<?> record);
+
+    /**
+     * Called at the beginning of each flush cycle, before any keys are processed.
+     *
+     * <p>This callback fires once per punctuator invocation. It is always followed by
+     * a corresponding {@link #onFlushCompleted(int, int)} call.
+     *
+     * @param isFullScan {@code true} on the first flush after startup or partition rebalance,
+     *                   when the processor performs a full state store scan to recover previously
+     *                   buffered records; {@code false} for all subsequent flushes, which use
+     *                   an efficient dirty-key lookup
+     */
+    void onFlushStarted(boolean isFullScan);
+
+    /**
+     * Called at the end of each flush cycle, after all dirty keys have been sorted, forwarded,
+     * and removed from the state store.
+     *
+     * <p>This callback fires once per punctuator invocation, after all
+     * {@link #onKeyFlushed(Object, int)} calls for this cycle have completed.
+     *
+     * @param keysCount    the number of distinct keys flushed in this cycle
+     * @param recordsCount the total number of records forwarded across all keys in this cycle
+     */
+    void onFlushCompleted(int keysCount, int recordsCount);
+
+    /**
+     * Called after a single key's buffered records have been sorted and forwarded downstream,
+     * and before the key's entry is deleted from the state store.
+     *
+     * <p>This callback fires once per distinct key per flush cycle. It is only called when
+     * the key has at least one buffered record; keys with null or empty record lists are skipped.
+     *
+     * @param key         the input key (before any key mapping applied by the processor)
+     * @param recordCount the number of records sorted and forwarded for this key
+     */
+    void onKeyFlushed(Object key, int recordCount);
+
+    /**
+     * Called when an incoming record has a null value, indicating a tombstone.
+     *
+     * <p>This callback fires in addition to {@link #onRecordBuffered(Object, BufferedRecord)}
+     * when the record value is null. Tombstones are valid domain events — they are buffered and
+     * forwarded downstream in sorted order according to the processor's {@link
+     * com.snekse.kafka.streams.resequence.domain.TombstoneSortOrder} configuration.
+     *
+     * <p>The {@code record} parameter will have a null {@code record} field
+     * ({@code bufferedRecord.getRecord() == null}) but will carry valid Kafka metadata
+     * (partition, offset, timestamp).
+     *
+     * @param key    the record's input key
+     * @param record the buffered tombstone record with Kafka metadata
+     */
+    void onTombstoneReceived(Object key, BufferedRecord<?> record);
+
+    /**
+     * Called when an incoming record is silently ignored because its key is null.
+     *
+     * <p>Null-key records cannot be stored in the Kafka Streams state store. The record
+     * is not buffered and will not appear in the output topic. This callback provides
+     * visibility into such data quality events.
+     */
+    void onRecordIgnored();
+
+    /**
+     * Returns a no-op implementation that does nothing for all callbacks.
+     *
+     * <p>This is the default listener used when no listener is explicitly provided to
+     * {@link com.snekse.kafka.streams.resequence.processor.ResequenceProcessor}.
+     *
+     * @return a stateless no-op {@code ResequenceEventListener}
+     */
+    static ResequenceEventListener noOp() {
+        return new ResequenceEventListener() {
+            public void onRecordBuffered(Object key, BufferedRecord<?> record) {}
+            public void onTombstoneReceived(Object key, BufferedRecord<?> record) {}
+            public void onFlushStarted(boolean isFullScan) {}
+            public void onFlushCompleted(int keysCount, int recordsCount) {}
+            public void onKeyFlushed(Object key, int recordCount) {}
+            public void onRecordIgnored() {}
+        };
+    }
+}
+```
+
+**Key decisions**:
+- `Object` key type avoids generic type parameter on the interface — callers only need it for logging/tagging, not type-safe access
+- `noOp()` returns an anonymous class (not a lambda) so all five methods are satisfied in one block; a singleton constant would also be acceptable
+- Javadoc on each method documents when it fires
+
+**Implementation steps**:
+
+1. Create the `listener` package directory under `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/`
+2. Create `ResequenceEventListener.java` with the interface and `noOp()` factory above
+3. Compile: `./gradlew :resequence-starter:compileJava`
+
+**Feedback loop**:
+- **Playground**: Compile check — no test needed yet for the interface alone
+- **Experiment**: Confirm the class is resolvable from other packages
+- **Check command**: `./gradlew :resequence-starter:compileJava`
+
+---
+
+### ResequenceProcessor — Listener Wiring
+
+**Pattern to follow**: `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/processor/ResequenceProcessor.java` (existing constructor chaining pattern)
+
+**Overview**: Add a `ResequenceEventListener` field and a new constructor that accepts it. The two existing constructors chain to the new one with `ResequenceEventListener.noOp()`. Listener calls are inserted at 6 points across `process()`, `flushAll()`, `flushViaFullScan()`, `flushViaDirtyKeys()`, and `flushKey()`.
+
+```java
+// New field (add with other finals)
+private final ResequenceEventListener listener;
+
+// Existing 3-arg constructor — unchanged signature, now chains to 6-arg
+@SuppressWarnings({"unchecked", "unused"})
+public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval) {
+    this(comparator, stateStoreName, flushInterval, null,
+         (ValueMapper<KR, V, VR>) ValueMapper.noOp(), ResequenceEventListener.noOp());
+}
+
+// Existing 5-arg constructor — unchanged signature, now chains to 6-arg
+@SuppressWarnings("unchecked")
+public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval,
+                           KeyMapper<K, KR> keyMapper, ValueMapper<KR, V, VR> valueMapper) {
+    this(comparator, stateStoreName, flushInterval, keyMapper, valueMapper, ResequenceEventListener.noOp());
+}
+
+// New 6-arg constructor — canonical
+@SuppressWarnings("unchecked")
+public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval,
+                           KeyMapper<K, KR> keyMapper, ValueMapper<KR, V, VR> valueMapper,
+                           ResequenceEventListener listener) {
+    this.comparator = comparator;
+    this.stateStoreName = stateStoreName;
+    this.flushInterval = flushInterval;
+    this.keyMapper = keyMapper;
+    this.valueMapper = valueMapper != null ? valueMapper : (ValueMapper<KR, V, VR>) ValueMapper.noOp();
+    this.listener = listener != null ? listener : ResequenceEventListener.noOp();
+}
+```
+
+**Listener call sites** (6 total):
+
+```java
+// ── process() ────────────────────────────────────────────────────────────────
+
+@Override
+public void process(Record<K, V> record) {
+    K key = record.key();
+    V value = record.value();
+
+    // Call site 1: null key — record is silently ignored
+    if (key == null) {
+        listener.onRecordIgnored();
+        return;
+    }
+
+    // `buffered` is defined here — it holds the wrapped value with Kafka metadata
+    BufferedRecord<V> buffered = BufferedRecord.<V>builder()
+            .record(value)
+            .partition(context().recordMetadata().map(RecordMetadata::partition).orElse(-1))
+            .offset(context().recordMetadata().map(RecordMetadata::offset).orElse(-1L))
+            .timestamp(record.timestamp())
+            .build();
+
+    List<BufferedRecord<V>> records = store.get(key);
+    if (records == null) {
+        records = new ArrayList<>();
+    }
+    records.add(buffered);
+    store.put(key, records);
+    dirtyKeys.add(key);
+
+    // Call site 2: tombstone — null value buffered as a domain event (fires before onRecordBuffered)
+    if (value == null) {
+        listener.onTombstoneReceived(key, buffered);
+    }
+
+    // Call site 3: record successfully buffered (fires for all records, including tombstones)
+    listener.onRecordBuffered(key, buffered);
+}
+
+// ── flushAll() ───────────────────────────────────────────────────────────────
+
+// Call site 4: flush cycle starts
+// `int[] totals` is created here and threaded through to accumulate counts
+private void flushAll(long timestamp) {
+    listener.onFlushStarted(needsRecoveryScan);
+    int[] totals = {0, 0}; // [keysCount, recordsCount]
+    if (needsRecoveryScan) {
+        flushViaFullScan(timestamp, totals);  // signature updated — see below
+        needsRecoveryScan = false;
+    } else {
+        flushViaDirtyKeys(timestamp, totals); // signature updated — see below
+    }
+    dirtyKeys.clear();
+    listener.onFlushCompleted(totals[0], totals[1]); // call site 6 (see flushKey)
+}
+
+// ── flushViaFullScan() / flushViaDirtyKeys() — updated signatures ────────────
+// Both methods gain an `int[] totals` parameter and thread it through to flushKey.
+
+private void flushViaFullScan(long timestamp, int[] totals) {
+    try (KeyValueIterator<K, List<BufferedRecord<V>>> iter = store.all()) {
+        while (iter.hasNext()) {
+            var entry = iter.next();
+            flushKey(entry.key, entry.value, timestamp, totals);
+        }
+    }
+}
+
+private void flushViaDirtyKeys(long timestamp, int[] totals) {
+    for (K key : dirtyKeys) {
+        List<BufferedRecord<V>> records = store.get(key);
+        flushKey(key, records, timestamp, totals);
+    }
+}
+
+// ── flushKey() ───────────────────────────────────────────────────────────────
+
+@SuppressWarnings("unchecked")
+private void flushKey(K key, List<BufferedRecord<V>> records, long timestamp, int[] totals) {
+    if (records == null || records.isEmpty()) return;
+
+    records.sort(comparator);
+    KR outputKey = keyMapper != null ? keyMapper.map(key) : (KR) key;
+
+    for (BufferedRecord<V> br : records) {
+        VR mappedValue = valueMapper.mapValue(outputKey, br);
+        context().forward(new Record<>(outputKey, mappedValue, timestamp));
+    }
+
+    // Call site 5: key fully flushed — fires BEFORE store.delete (matches javadoc contract)
+    listener.onKeyFlushed(key, records.size());
+    store.delete(key);
+
+    // Accumulate totals for onFlushCompleted (call site 6, fired in flushAll)
+    totals[0]++;
+    totals[1] += records.size();
+}
+```
+
+**Key decisions**:
+- `onTombstoneReceived` fires before `onRecordBuffered` for null-value records — "specific before generic" lets listeners short-circuit if they only care about tombstones, while `onRecordBuffered` still fires so total-count listeners don't need special-casing
+- `onRecordIgnored` replaces `onNullKeyDropped` — semantically a record was ignored/skipped, not "dropped" (which implies it arrived successfully and was then discarded)
+- `int[]` totals array is created in `flushAll` and passed through `flushViaFullScan`/`flushViaDirtyKeys` to `flushKey` — all three method signatures require updating
+- `onKeyFlushed` fires *before* `store.delete` so that if a listener inspects the store, the entry is still present; the javadoc on the interface makes this guarantee explicit
+- `onFlushStarted` receives `needsRecoveryScan` *before* it's reset to `false`
+
+**Implementation steps**:
+
+1. Add `import com.snekse.kafka.streams.resequence.listener.ResequenceEventListener;` to `ResequenceProcessor.java`
+2. Add `private final ResequenceEventListener listener;` field
+3. Update existing 3-arg constructor to chain to the new 6-arg constructor with `ResequenceEventListener.noOp()`
+4. Update existing 5-arg constructor to chain to the new 6-arg constructor with `ResequenceEventListener.noOp()`
+5. Add new 6-arg constructor with null-coalescing for `listener`
+6. In `process()`: add `listener.onRecordIgnored()` before the null-key `return`; after `store.put`/`dirtyKeys.add`, add `onTombstoneReceived` (guarded by `value == null`) then `onRecordBuffered`
+7. In `flushAll()`: add `listener.onFlushStarted(needsRecoveryScan)` before the branch; add `int[] totals = {0, 0}`; update calls to `flushViaFullScan` and `flushViaDirtyKeys` to pass `totals`; add `listener.onFlushCompleted(totals[0], totals[1])` after `dirtyKeys.clear()`
+8. Update `flushViaFullScan(long timestamp)` → `flushViaFullScan(long timestamp, int[] totals)`; thread `totals` to `flushKey`
+9. Update `flushViaDirtyKeys(long timestamp)` → `flushViaDirtyKeys(long timestamp, int[] totals)`; thread `totals` to `flushKey`
+10. Update `flushKey(K key, ..., long timestamp)` → add `int[] totals` param; move `listener.onKeyFlushed` call to before `store.delete`; add `totals[0]++` and `totals[1] += records.size()` after delete
+11. Run tests: `./gradlew :resequence-starter:test`
+
+**Feedback loop**:
+- **Playground**: Existing `ResequenceProcessorSpec` — run it to verify no regressions
+- **Experiment**: All existing test cases pass with the no-op listener; new spec adds mock-listener cases
+- **Check command**: `./gradlew :resequence-starter:test`
+
+---
+
+### ResequenceEventListenerSpec
+
+**Pattern to follow**: `resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/processor/ResequenceProcessorSpec.groovy` (TopologyTestDriver setup, test record pattern)
+
+**Overview**: Verifies that each listener callback fires at the right time with the right arguments. Uses a Spock `Mock(ResequenceEventListener)` so interaction counts and argument values can be asserted with `_` wildcards and specific matchers.
+
+```groovy
+package com.snekse.kafka.streams.resequence.listener
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord
+import com.snekse.kafka.streams.resequence.domain.ResequenceComparator
+import com.snekse.kafka.streams.resequence.domain.TombstoneSortOrder
+import com.snekse.kafka.streams.resequence.processor.ResequenceProcessor
+import com.snekse.kafka.streams.resequence.serde.BufferedRecordListSerde
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.TopologyTestDriver
+import org.apache.kafka.streams.state.Stores
+import org.springframework.kafka.support.serializer.JacksonJsonSerde
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import tools.jackson.databind.json.JsonMapper
+
+import java.time.Duration
+
+class ResequenceEventListenerSpec extends Specification {
+
+    static final String SOURCE_TOPIC = 'input'
+    static final String SINK_TOPIC = 'output'
+    static final String STATE_STORE = 'test-store'
+    static final Duration FLUSH_INTERVAL = Duration.ofMillis(100)
+
+    @AutoCleanup
+    TopologyTestDriver driver
+
+    ResequenceEventListener listener = Mock()
+
+    // Build driver with the mock listener injected
+    private TopologyTestDriver buildDriver(ResequenceEventListener l) {
+        // ... same topology wiring as ResequenceProcessorSpec but using 6-arg constructor
+    }
+}
+```
+
+**Key test cases**:
+
+- `onNullKeyDropped` fires once when a null-key record is sent; no buffering, no output
+- `onRecordBuffered` fires once per valid record, with the correct key and a non-null `BufferedRecord`
+- `onFlushStarted(true)` fires on the first flush after driver creation (recovery scan)
+- `onFlushStarted(false)` fires on subsequent flushes
+- `onKeyFlushed` fires once per distinct key in a flush, with correct record count
+- `onFlushCompleted` fires once per flush with correct `keysCount` and `recordsCount` totals
+- `noOp()` listener: existing processor behavior unchanged, all tests pass with no mocking
+
+**Implementation steps**:
+
+1. Create `ResequenceEventListenerSpec.groovy` in the `listener` package
+2. Wire topology using the same `TopologyTestDriver` pattern from `ResequenceProcessorSpec` — copy the setup helper, swap in the 6-arg `ResequenceProcessor` constructor with `listener`
+3. Write one `when/then` block per callback
+4. Run: `./gradlew :resequence-starter:test`
+
+**Feedback loop**:
+- **Playground**: `./gradlew :resequence-starter:test --tests "*.ResequenceEventListenerSpec"`
+- **Experiment**: Add one record, advance wall clock past flush interval, assert interaction counts
+- **Check command**: `./gradlew :resequence-starter:test --tests "*.ResequenceEventListenerSpec"`
+
+## Testing Requirements
+
+### Unit Tests
+
+| Test File | Coverage |
+| --- | --- |
+| `resequence-starter/src/test/groovy/.../listener/ResequenceEventListenerSpec.groovy` | All 6 listener callbacks; tombstone vs normal record distinction; ignored record path; first-flush vs subsequent-flush; totals accuracy |
+
+**Key test cases**:
+- Send 1 null-key record → `onRecordIgnored` called 1 time; `onRecordBuffered` never called; no output
+- Send 1 null-value record (tombstone) → `onTombstoneReceived` called 1 time AND `onRecordBuffered` called 1 time (both fire)
+- Send 1 non-null record → `onRecordBuffered` called 1 time; `onTombstoneReceived` never called
+- Send 3 valid records under 2 keys, advance clock → `onFlushCompleted(2, 3)` on first flush
+- Send 2 records for same key → `onKeyFlushed(key, 2)` on flush
+- Advance clock twice → `onFlushStarted(true)` on first flush, `onFlushStarted(false)` on second
+- Use `noOp()` listener → existing processor tests unaffected
+
+### Manual Testing
+
+- [ ] Run `./gradlew :resequence-starter:test` — all tests pass including existing `ResequenceProcessorSpec`
+
+## Error Handling
+
+| Error Scenario | Handling Strategy |
+| --- | --- |
+| Listener throws exception in callback | Let it propagate — same contract as KStreams processor exceptions; don't silently swallow |
+| `null` listener passed to 6-arg constructor | Coerce to `noOp()` (matches existing null-coalescing pattern for `valueMapper`) |
+
+## Validation Commands
+
+```bash
+# Build and test the starter module only
+./gradlew :resequence-starter:test
+
+# Verify no regressions in the full build
+./gradlew clean build
+```
+
+---
+
+_This spec is ready for implementation. Follow the patterns and validate at each step._

--- a/docs/ideation/resequence-observability/spec-phase-2.md
+++ b/docs/ideation/resequence-observability/spec-phase-2.md
@@ -1,0 +1,543 @@
+# Implementation Spec: Resequence Observability - Phase 2
+
+**Contract**: ./contract.md
+**Estimated Effort**: M
+
+## Technical Approach
+
+This phase adds the OTel implementation and wires everything into auto-configuration and the sample-app. Three independent concerns:
+
+1. **OTel implementation** — `OtelResequenceEventListener` in `resequence-starter` uses `opentelemetry-api` (`compileOnly`) to emit counters, histograms, and a gauge. The class also maintains simple `AtomicLong` accumulators alongside the OTel instruments so the sample-app can log totals on shutdown without needing an OTel metric reader.
+
+2. **Auto-configuration** — `ResequenceAutoConfiguration` gets a `@ConditionalOnClass(OpenTelemetry.class)` + `@ConditionalOnMissingBean(ResequenceEventListener.class)` bean that auto-registers the OTel listener when the OTel API is on the runtime classpath. An `otel.enabled` flag in `ResequenceProperties` allows opt-out.
+
+3. **Sample-app wiring** — add OTel SDK dependencies, inject the auto-configured listener into `ResequenceTopologyConfig`, and add a `MetricsShutdownLogger` that logs accumulated totals on `ContextClosedEvent`.
+
+The `opentelemetry-api` is `compileOnly` in `resequence-starter` — it must not appear in the published `api` or `implementation` configurations. Users who want OTel metrics add the OTel API (or SDK) to their own runtime classpath. Users who don't bring OTel get the no-op listener automatically.
+
+## Feedback Strategy
+
+**Inner-loop command**: `./gradlew :resequence-starter:test`
+
+**Playground**: Test suite — `OtelResequenceEventListenerSpec` in the **`resequence-starter` module** (not sample-app) uses OTel's `InMemoryMetricReader` to assert metric values after processor operations. OTel metric correctness is verified entirely within the library module; the sample-app only demonstrates runtime wiring and shutdown logging.
+
+**Why this approach**: The OTel SDK testing module provides a synchronous in-memory reader that returns all collected metrics on demand — ideal for Spock `then:` blocks with precise assertions. Keeping these tests in `resequence-starter` means the library self-validates its own instrumentation without depending on the sample-app.
+
+## File Changes
+
+### New Files
+
+| File Path | Purpose |
+| --- | --- |
+| `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListener.java` | OTel implementation of `ResequenceEventListener`; emits counters, histograms, and accumulates totals |
+| `resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListenerSpec.groovy` | Spock spec using `InMemoryMetricReader` to assert OTel metric values |
+| `sample-app/src/main/java/com/example/sampleapp/observability/MetricsShutdownLogger.java` | `ApplicationListener<ContextClosedEvent>` that logs metric totals from `OtelResequenceEventListener` on shutdown |
+
+### Modified Files
+
+| File Path | Changes |
+| --- | --- |
+| `resequence-starter/build.gradle.kts` | Add `compileOnly("io.opentelemetry:opentelemetry-api")` and `testImplementation("io.opentelemetry:opentelemetry-sdk-testing")` |
+| `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceProperties.java` | Add nested `OtelProperties` inner class with `enabled` boolean; expose via `getOtel()` |
+| `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceAutoConfiguration.java` | Add OTel conditional bean for `OtelResequenceEventListener`; fallback no-op bean |
+| `sample-app/build.gradle.kts` | Add OTel SDK + logging exporter dependencies |
+| `sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java` | Inject `ResequenceEventListener` bean; pass it to `ResequenceProcessor` constructor |
+
+## Implementation Details
+
+### OtelResequenceEventListener
+
+**Pattern to follow**: `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/ResequenceEventListener.java` (implements the interface from Phase 1)
+
+**Overview**: Wraps OTel API instruments. All instruments are created once in the constructor from the provided `OpenTelemetry` instance. Flush duration timing uses a simple long field — safe because KStreams processors are single-threaded.
+
+```java
+package com.snekse.kafka.streams.resequence.listener;
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class OtelResequenceEventListener implements ResequenceEventListener {
+
+    private static final String INSTRUMENTATION_NAME = "com.snekse.kafka.streams.resequence";
+    private static final AttributeKey<Boolean> FULL_SCAN = AttributeKey.booleanKey("full_scan");
+
+    // OTel instruments
+    private final LongCounter recordsBuffered;
+    private final LongCounter tombstonesReceived;
+    private final LongCounter recordsIgnored;
+    private final LongCounter recordsForwarded;
+    private final LongCounter flushCount;
+    private final LongHistogram flushDurationMs;
+    private final LongHistogram bufferSize;
+
+    // Simple accumulators for shutdown summary logging
+    private final AtomicLong totalRecordsBuffered = new AtomicLong();
+    private final AtomicLong totalTombstonesReceived = new AtomicLong();
+    private final AtomicLong totalRecordsIgnored = new AtomicLong();
+    private final AtomicLong totalRecordsForwarded = new AtomicLong();
+    private final AtomicLong totalFlushes = new AtomicLong();
+
+    // Flush timing and scan state (single-threaded — KStreams processors are not concurrent)
+    private long flushStartNanos;
+    private boolean lastFlushWasFullScan;
+
+    public OtelResequenceEventListener(OpenTelemetry openTelemetry) {
+        Meter meter = openTelemetry.getMeter(INSTRUMENTATION_NAME);
+
+        recordsBuffered = meter.counterBuilder("resequence.records.buffered")
+                .setDescription("Number of records appended to the resequence buffer (includes tombstones)")
+                .setUnit("{record}")
+                .build();
+
+        tombstonesReceived = meter.counterBuilder("resequence.tombstones.received")
+                .setDescription("Number of tombstone (null-value) records buffered")
+                .setUnit("{record}")
+                .build();
+
+        recordsIgnored = meter.counterBuilder("resequence.records.ignored")
+                .setDescription("Number of records silently ignored due to null key")
+                .setUnit("{record}")
+                .build();
+
+        recordsForwarded = meter.counterBuilder("resequence.records.forwarded")
+                .setDescription("Number of records sorted and forwarded downstream")
+                .setUnit("{record}")
+                .build();
+
+        flushCount = meter.counterBuilder("resequence.flushes")
+                .setDescription("Number of flush cycles completed")
+                .setUnit("{flush}")
+                .build();
+
+        flushDurationMs = meter.histogramBuilder("resequence.flush.duration")
+                .ofLongs()
+                .setDescription("Duration of each flush cycle in milliseconds")
+                .setUnit("ms")
+                .build();
+
+        bufferSize = meter.histogramBuilder("resequence.buffer.size")
+                .ofLongs()
+                .setDescription("Number of records per key at flush time")
+                .setUnit("{record}")
+                .build();
+    }
+
+    @Override
+    public void onRecordBuffered(Object key, BufferedRecord<?> record) {
+        recordsBuffered.add(1);
+        totalRecordsBuffered.incrementAndGet();
+    }
+
+    @Override
+    public void onTombstoneReceived(Object key, BufferedRecord<?> record) {
+        tombstonesReceived.add(1);
+        totalTombstonesReceived.incrementAndGet();
+    }
+
+    @Override
+    public void onRecordIgnored() {
+        recordsIgnored.add(1);
+        totalRecordsIgnored.incrementAndGet();
+    }
+
+    @Override
+    public void onFlushStarted(boolean isFullScan) {
+        this.lastFlushWasFullScan = isFullScan; // stored for use in onFlushCompleted
+        flushStartNanos = System.nanoTime();
+    }
+
+    @Override
+    public void onFlushCompleted(int keysCount, int recordsCount) {
+        long durationMs = (System.nanoTime() - flushStartNanos) / 1_000_000;
+        flushDurationMs.record(durationMs);
+        flushCount.add(1, Attributes.of(FULL_SCAN, lastFlushWasFullScan));
+        totalRecordsForwarded.addAndGet(recordsCount);
+        totalFlushes.incrementAndGet();
+    }
+
+    @Override
+    public void onKeyFlushed(Object key, int recordCount) {
+        recordsForwarded.add(recordCount);
+        bufferSize.record(recordCount);
+    }
+
+    // Accessors for shutdown summary logging
+    public long getTotalRecordsBuffered() { return totalRecordsBuffered.get(); }
+    public long getTotalTombstonesReceived() { return totalTombstonesReceived.get(); }
+    public long getTotalRecordsIgnored() { return totalRecordsIgnored.get(); }
+    public long getTotalRecordsForwarded() { return totalRecordsForwarded.get(); }
+    public long getTotalFlushes() { return totalFlushes.get(); }
+}
+```
+
+**Key decisions**:
+- `AtomicLong` accumulators alongside OTel instruments — this lets `MetricsShutdownLogger` log totals without needing an OTel `MetricReader` in the sample-app
+- `flushStartNanos` is a plain field (not AtomicLong) — KStreams processor threads are single-threaded per task; this is safe
+- `INSTRUMENTATION_NAME` matches the library's root package for conventional OTel naming
+- `lastFlushWasFullScan` is stored in `onFlushStarted` and read in `onFlushCompleted` to attach the `full_scan` attribute to the flush counter — since the two callbacks are paired and KStreams is single-threaded, a plain field is safe
+
+**Implementation steps**:
+
+1. Add OTel `compileOnly` dep to `resequence-starter/build.gradle.kts` (see build changes below) and sync
+2. Create `OtelResequenceEventListener.java` in the `listener` package
+3. Verify `compileOnly` means OTel classes are present at compile time: `./gradlew :resequence-starter:compileJava`
+4. Confirm the starter JAR does NOT include OTel classes (only the interface usage): `./gradlew :resequence-starter:jar && jar tf resequence-starter/build/libs/*.jar | grep opentelemetry` — should return nothing
+
+**Feedback loop**:
+- **Playground**: `OtelResequenceEventListenerSpec` (set up in next component)
+- **Experiment**: Send N records → assert counter value equals N
+- **Check command**: `./gradlew :resequence-starter:test --tests "*.OtelResequenceEventListenerSpec"`
+
+---
+
+### OtelResequenceEventListenerSpec
+
+**Location**: `resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListenerSpec.groovy`
+— this is a **`resequence-starter` module test**, not a sample-app test. The `opentelemetry-sdk-testing` dependency is added to `resequence-starter`'s `testImplementation` configuration for exactly this purpose.
+
+**Pattern to follow**: `resequence-starter/src/test/groovy/.../processor/ResequenceProcessorSpec.groovy` (TopologyTestDriver setup)
+
+**Overview**: Integration test that wires a real `OtelResequenceEventListener` (backed by `InMemoryMetricReader`) into a processor topology, runs records through it, and asserts on collected metric values. All OTel correctness verification happens here — the sample-app is not used for metric assertions.
+
+```groovy
+package com.snekse.kafka.streams.resequence.listener
+
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import spock.lang.Specification
+
+class OtelResequenceEventListenerSpec extends Specification {
+
+    InMemoryMetricReader metricReader
+    OtelResequenceEventListener otelListener
+    // TopologyTestDriver setup (same pattern as ResequenceProcessorSpec)
+
+    def setup() {
+        metricReader = InMemoryMetricReader.create()
+        def meterProvider = SdkMeterProvider.builder()
+                .registerMetricReader(metricReader)
+                .build()
+        def openTelemetry = OpenTelemetrySdk.builder()
+                .setMeterProvider(meterProvider)
+                .build()
+        otelListener = new OtelResequenceEventListener(openTelemetry)
+        // build topology driver with otelListener injected
+    }
+
+    def "records buffered counter increments for each valid record"() {
+        when:
+        // send 3 records through topology
+        then:
+        def metrics = metricReader.collectAllMetrics()
+        def buffered = findCounter(metrics, "resequence.records.buffered")
+        buffered.value == 3
+    }
+
+    def "null key drop counter increments and records are not buffered"() { ... }
+    def "flush duration histogram records a value after flush"() { ... }
+    def "buffer size histogram records per-key record counts"() { ... }
+    def "records forwarded counter equals total records sent (no nulls)"() { ... }
+    def "flush count increments each flush cycle"() { ... }
+    def "accumulator getters match counter values"() { ... }
+}
+```
+
+**Key decisions**:
+- Use `InMemoryMetricReader.create()` (synchronous, no scheduled collection) — `collectAllMetrics()` is called on demand in `then:` blocks
+- Assert on the `InMemoryMetricReader` output, not `AtomicLong` accumulators, for OTel correctness; separately assert accumulators match (one test)
+- Advance topology wall clock past flush interval to trigger flush before asserting flush metrics
+
+**Implementation steps**:
+
+1. Add `testImplementation("io.opentelemetry:opentelemetry-sdk-testing")` to `resequence-starter/build.gradle.kts`
+2. Create `OtelResequenceEventListenerSpec.groovy`
+3. Wire topology using `TopologyTestDriver` with `otelListener` passed to 6-arg `ResequenceProcessor` constructor
+4. Implement metric lookup helper (find metric by name from `Collection<MetricData>`)
+5. Write test cases listed above
+6. Run: `./gradlew :resequence-starter:test`
+
+**Feedback loop**:
+- **Playground**: `./gradlew :resequence-starter:test --tests "*.OtelResequenceEventListenerSpec"`
+- **Experiment**: Vary record count and assert counter equals that count; advance clock once and twice to check flush count
+- **Check command**: `./gradlew :resequence-starter:test --tests "*.OtelResequenceEventListenerSpec"`
+
+---
+
+### Build Dependencies
+
+**resequence-starter/build.gradle.kts** — add to `dependencies` block:
+
+```kotlin
+// OTel API — compileOnly so users are NOT forced to bring it transitively
+compileOnly("io.opentelemetry:opentelemetry-api")
+
+// OTel SDK testing utilities — only needed in tests
+testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+```
+
+**Note**: Do NOT use `implementation` or `api` — those would leak OTel onto users' compile and runtime classpaths. `compileOnly` keeps it strictly at compile time for this module.
+
+**Note on version**: Spring Boot 4.x dependency management may or may not include OTel API. Check if `./gradlew :resequence-starter:dependencies` resolves `opentelemetry-api` from the Spring BOM. If not, pin an explicit version (e.g., `"io.opentelemetry:opentelemetry-api:1.40.0"`) — check Maven Central for the latest stable 1.x release at implementation time.
+
+---
+
+### ResequenceProperties — OTel Nested Config
+
+**Pattern to follow**: Existing `ResequenceProperties.java` constructor-injection style.
+
+**Overview**: Add a nested `OtelProperties` class that maps to `resequence.otel.*` properties. The main class gains an `otel` field with a `getOtel()` accessor.
+
+```java
+// New nested class (static inner class of ResequenceProperties)
+public static class OtelProperties {
+    private final boolean enabled;
+
+    public OtelProperties(Boolean enabled) {
+        this.enabled = enabled != null ? enabled : true;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}
+
+// Updated ResequenceProperties constructor
+public ResequenceProperties(String stateStoreName, Duration flushInterval,
+                            TombstoneSortOrder tombstoneSortOrder,
+                            OtelProperties otel) {
+    this.stateStoreName = stateStoreName != null ? stateStoreName : "resequence-buffer";
+    this.flushInterval = flushInterval != null ? flushInterval : Duration.ofSeconds(2);
+    this.tombstoneSortOrder = tombstoneSortOrder != null ? tombstoneSortOrder : TombstoneSortOrder.LAST;
+    this.otel = otel != null ? otel : new OtelProperties(null);
+}
+
+public OtelProperties getOtel() { return otel; }
+```
+
+**Key decisions**:
+- Nested class maps `resequence.otel.enabled=false` naturally via Spring Boot's nested config binding
+- Default is `enabled = true` (opt-out, not opt-in) — consistent with Spring Boot auto-configuration convention
+- The outer constructor gains a new `OtelProperties otel` parameter; Spring Boot's `@ConfigurationProperties` constructor binding handles the nested object automatically
+
+**Implementation steps**:
+1. Add `private final OtelProperties otel;` field to `ResequenceProperties`
+2. Add `OtelProperties` static inner class
+3. Add `otel` parameter to the main constructor with null-coalescing
+4. Add `getOtel()` accessor
+5. Confirm: `./gradlew :resequence-starter:compileJava`
+
+---
+
+### ResequenceAutoConfiguration — OTel Conditional Bean
+
+**Pattern to follow**: `resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceAutoConfiguration.java`
+
+**Overview**: Register an `OtelResequenceEventListener` bean when OTel API is on the classpath and `resequence.otel.enabled` is true. Fall back to a `ResequenceEventListener.noOp()` bean when OTel is not available.
+
+```java
+@AutoConfiguration
+@EnableConfigurationProperties(ResequenceProperties.class)
+public class ResequenceAutoConfiguration {
+
+    /**
+     * Registers an OTel-backed listener when:
+     * 1. opentelemetry-api is on the runtime classpath
+     * 2. No user-provided ResequenceEventListener bean exists
+     * 3. resequence.otel.enabled is not false
+     */
+    @Bean
+    @ConditionalOnClass(name = "io.opentelemetry.api.OpenTelemetry")
+    @ConditionalOnMissingBean(ResequenceEventListener.class)
+    @ConditionalOnProperty(prefix = "resequence.otel", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public ResequenceEventListener otelResequenceEventListener(OpenTelemetry openTelemetry) {
+        return new OtelResequenceEventListener(openTelemetry);
+    }
+
+    /**
+     * Fallback no-op listener when OTel is not configured or disabled.
+     */
+    @Bean
+    @ConditionalOnMissingBean(ResequenceEventListener.class)
+    public ResequenceEventListener noOpResequenceEventListener() {
+        return ResequenceEventListener.noOp();
+    }
+}
+```
+
+**Key decisions**:
+- `@ConditionalOnClass(name = "io.opentelemetry.api.OpenTelemetry")` uses the string form because the class is `compileOnly` — using the class literal directly would cause a `NoClassDefFoundError` if OTel is absent at runtime
+- `@ConditionalOnMissingBean(ResequenceEventListener.class)` ensures user-provided beans always take precedence over auto-configured ones
+- `@ConditionalOnProperty(matchIfMissing = true)` means OTel is enabled by default when the property is absent
+- The `OpenTelemetry openTelemetry` parameter in `otelResequenceEventListener` — users must provide an `OpenTelemetry` bean (e.g., via `opentelemetry-spring-boot-starter`); the auto-config relies on it being present when OTel is on the classpath
+- Add required imports: `OpenTelemetry` from `io.opentelemetry.api` — use `compileOnly` scope in auto-config, same as the listener
+
+**Implementation steps**:
+
+1. Add the two `@Bean` methods to `ResequenceAutoConfiguration`
+2. Add imports for `ConditionalOnClass`, `ConditionalOnMissingBean`, `ConditionalOnProperty`, `OpenTelemetry`, `OtelResequenceEventListener`, `ResequenceEventListener`
+3. Verify: `./gradlew :resequence-starter:compileJava`
+
+---
+
+### Sample-App Build Dependencies
+
+**sample-app/build.gradle.kts** — add OTel SDK so the OTel auto-config bean can be resolved at runtime:
+
+```kotlin
+// OTel API + SDK — runtime dependency for the sample-app
+implementation("io.opentelemetry:opentelemetry-api")
+implementation("io.opentelemetry:opentelemetry-sdk")
+
+// Provides a Spring Boot auto-configured OpenTelemetry bean (GlobalOpenTelemetry)
+// Alternatively, manually create an OpenTelemetry bean in a @Configuration class
+implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")
+```
+
+**Note**: If `opentelemetry-spring-boot-starter` introduces too many transitive dependencies, the alternative is a simple `@Configuration` class that creates an `OpenTelemetrySdk` bean with an `InMemoryMetricReader` or `LoggingMetricExporter`. The spec prefers the starter for simplicity but the executing agent should evaluate what's available at implementation time and pick the lightest option.
+
+**OTel version note**: Check if the Spring Boot 4.x BOM manages `io.opentelemetry` versions. If not, align with whatever version was used in the `resequence-starter` `compileOnly` dep.
+
+---
+
+### ResequenceTopologyConfig — Inject Listener
+
+**Pattern to follow**: `sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java` (existing method parameter injection pattern)
+
+**Changes**:
+1. Add `ResequenceEventListener listener` as a parameter to `resequencingTopology(...)` — Spring injects the auto-configured bean
+2. Update the `topology.addProcessor(...)` call to use the 6-arg `ResequenceProcessor` constructor:
+
+```java
+// Before
+() -> new ResequenceProcessor<>(resequenceComparator, stateStoreName, resequenceProperties.getFlushInterval(), keyMapper, valueMapper)
+
+// After
+() -> new ResequenceProcessor<>(resequenceComparator, stateStoreName, resequenceProperties.getFlushInterval(), keyMapper, valueMapper, listener)
+```
+
+3. Add import: `import com.snekse.kafka.streams.resequence.listener.ResequenceEventListener;`
+
+**Implementation steps**:
+1. Add `ResequenceEventListener listener` parameter to `resequencingTopology` method signature
+2. Update processor supplier lambda to pass `listener` as 6th arg
+3. Add import
+4. Verify: `./gradlew :sample-app:compileJava`
+
+---
+
+### MetricsShutdownLogger
+
+**Pattern to follow**: Standard Spring `ApplicationListener<E>` pattern.
+
+**Overview**: Logs a one-line metrics summary when the Spring application context closes. Injected with `OtelResequenceEventListener` by type to access the `AtomicLong` accumulators.
+
+```java
+package com.example.sampleapp.observability;
+
+import com.snekse.kafka.streams.resequence.listener.OtelResequenceEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsShutdownLogger implements ApplicationListener<ContextClosedEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsShutdownLogger.class);
+
+    private final OtelResequenceEventListener listener;
+
+    public MetricsShutdownLogger(OtelResequenceEventListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        log.info("Resequencer metrics summary — " +
+                "buffered={} tombstones={} ignored={} forwarded={} flushes={}",
+                listener.getTotalRecordsBuffered(),
+                listener.getTotalTombstonesReceived(),
+                listener.getTotalRecordsIgnored(),
+                listener.getTotalRecordsForwarded(),
+                listener.getTotalFlushes());
+    }
+}
+```
+
+**Key decisions**:
+- Inject `OtelResequenceEventListener` directly (not the interface) to access the accumulator getters — acceptable in the sample-app since it's a demonstration, not a library
+- Uses SLF4J `log.info` — visible in default Spring Boot console output without additional configuration
+- `@Component` is sufficient; no need for `@Order` since this is a logging-only shutdown hook
+
+**Implementation steps**:
+
+1. Create `observability` package under `sample-app/src/main/java/com/example/sampleapp/`
+2. Create `MetricsShutdownLogger.java`
+3. Verify: `./gradlew :sample-app:compileJava`
+
+## Testing Requirements
+
+### Unit Tests
+
+| Test File | Coverage |
+| --- | --- |
+| `resequence-starter/src/test/groovy/.../listener/OtelResequenceEventListenerSpec.groovy` | Counter values, histogram recordings, accumulator accessors, flush timing |
+
+**Key test cases**:
+- Send N non-null-value records → `resequence.records.buffered` counter == N; `resequence.tombstones.received` counter == 0
+- Send 1 null-value (tombstone) record → `resequence.records.buffered` counter == 1 AND `resequence.tombstones.received` counter == 1 (both fire)
+- Send 1 null-key record → `resequence.records.ignored` counter == 1; `resequence.records.buffered` counter == 0
+- Advance clock past flush interval → `resequence.flushes` counter == 1 (with `full_scan=true`); `resequence.flush.duration` histogram has 1 data point > 0
+- Advance clock a second time → second flush counter entry with `full_scan=false`
+- Send 3 records under same key → `resequence.buffer.size` histogram has 1 data point with value 3 after flush
+- Accumulator getters (`getTotalRecordsBuffered`, `getTotalTombstonesReceived`, `getTotalRecordsIgnored`, `getTotalRecordsForwarded`, `getTotalFlushes`) return values matching OTel counter readings
+- `OtelResequenceEventListener` created with `GlobalOpenTelemetry.get()` (no-op OTel) does not throw — validates compileOnly safety
+
+### Manual Testing
+
+- [ ] `./gradlew :sample-app:bootRun` starts without errors
+- [ ] Send some records to the source topic (or let the app idle)
+- [ ] Stop the app (Ctrl+C or SIGTERM) and observe the console for a `Resequencer metrics summary` log line
+- [ ] Verify the values look reasonable (buffered ≥ forwarded if app ran briefly, dropped == 0 for well-formed input)
+
+## Error Handling
+
+| Error Scenario | Handling Strategy |
+| --- | --- |
+| OTel API absent at runtime (user forgot SDK dep) | Auto-config no-op bean kicks in; processor works; OTel metrics silently absent |
+| `OpenTelemetry` bean not provided but API is on classpath | Spring fails to create `otelResequenceEventListener` bean — document that users must provide an `OpenTelemetry` bean or use `opentelemetry-spring-boot-starter` |
+| `MetricsShutdownLogger` constructed when `OtelResequenceEventListener` bean is absent | Spring injection fails at startup — `MetricsShutdownLogger` should use `Optional<OtelResequenceEventListener>` or check `@ConditionalOnBean(OtelResequenceEventListener.class)` |
+
+**Note on the third error**: If `resequence.otel.enabled=false` or OTel is absent, the auto-config registers a `ResequenceEventListener` no-op bean — not an `OtelResequenceEventListener` bean. The `MetricsShutdownLogger` injects `OtelResequenceEventListener` by type, so it would fail. Fix: annotate `MetricsShutdownLogger` with `@ConditionalOnBean(OtelResequenceEventListener.class)`, or change the constructor param to `Optional<OtelResequenceEventListener>` with a null guard in `onApplicationEvent`.
+
+## Validation Commands
+
+```bash
+# Verify compileOnly — OTel must NOT appear in the starter JAR
+./gradlew :resequence-starter:jar
+jar tf resequence-starter/build/libs/*.jar | grep opentelemetry  # should return nothing
+
+# Run resequence-starter tests including new OTel spec
+./gradlew :resequence-starter:test
+
+# Build everything
+./gradlew clean build
+
+# Manual end-to-end: start sample app and observe shutdown log
+./gradlew :sample-app:bootRun
+```
+
+---
+
+_This spec is ready for implementation. Follow the patterns and validate at each step._

--- a/resequence-starter/build.gradle.kts
+++ b/resequence-starter/build.gradle.kts
@@ -12,12 +12,16 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
+    // OTel API — compileOnly so it is NOT forced onto users' classpaths transitively
+    compileOnly("io.opentelemetry:opentelemetry-api")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-json")
     testImplementation("org.spockframework:spock-core:2.4-groovy-5.0")
     testImplementation("org.spockframework:spock-spring:2.4-groovy-5.0")
     testImplementation("org.apache.kafka:kafka-streams-test-utils")
     testImplementation("org.springframework.kafka:spring-kafka")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceAutoConfiguration.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceAutoConfiguration.java
@@ -1,9 +1,45 @@
 package com.snekse.kafka.streams.resequence.config;
 
+import com.snekse.kafka.streams.resequence.listener.OtelResequenceEventListener;
+import com.snekse.kafka.streams.resequence.listener.ResequenceEventListener;
+import io.opentelemetry.api.OpenTelemetry;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration
 @EnableConfigurationProperties(ResequenceProperties.class)
 public class ResequenceAutoConfiguration {
+
+    /**
+     * Registers an OTel-backed listener when:
+     * <ol>
+     *   <li>{@code opentelemetry-api} is on the runtime classpath</li>
+     *   <li>No user-provided {@link ResequenceEventListener} bean exists</li>
+     *   <li>{@code resequence.otel.enabled} is not {@code false}</li>
+     * </ol>
+     * Uses the string form of {@code @ConditionalOnClass} because {@code opentelemetry-api}
+     * is {@code compileOnly} in this module — referencing the class literal directly would
+     * cause a {@code NoClassDefFoundError} when OTel is absent at runtime.
+     */
+    @Bean
+    @ConditionalOnClass(name = "io.opentelemetry.api.OpenTelemetry")
+    @ConditionalOnMissingBean(ResequenceEventListener.class)
+    @ConditionalOnProperty(prefix = "resequence.otel", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public ResequenceEventListener otelResequenceEventListener(OpenTelemetry openTelemetry) {
+        return new OtelResequenceEventListener(openTelemetry);
+    }
+
+    /**
+     * Fallback no-op listener registered when OTel is absent, disabled, or a user-provided
+     * {@link ResequenceEventListener} bean already exists.
+     */
+    @Bean
+    @ConditionalOnMissingBean(ResequenceEventListener.class)
+    public ResequenceEventListener noOpResequenceEventListener() {
+        return ResequenceEventListener.noOp();
+    }
 }

--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceProperties.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/config/ResequenceProperties.java
@@ -11,11 +11,14 @@ public class ResequenceProperties {
     private final String stateStoreName;
     private final Duration flushInterval;
     private final TombstoneSortOrder tombstoneSortOrder;
+    private final OtelProperties otel;
 
-    public ResequenceProperties(String stateStoreName, Duration flushInterval, TombstoneSortOrder tombstoneSortOrder) {
+    public ResequenceProperties(String stateStoreName, Duration flushInterval,
+                                TombstoneSortOrder tombstoneSortOrder, OtelProperties otel) {
         this.stateStoreName = stateStoreName != null ? stateStoreName : "resequence-buffer";
         this.flushInterval = flushInterval != null ? flushInterval : Duration.ofSeconds(2);
         this.tombstoneSortOrder = tombstoneSortOrder != null ? tombstoneSortOrder : TombstoneSortOrder.LAST;
+        this.otel = otel != null ? otel : new OtelProperties(null);
     }
 
     public String getStateStoreName() {
@@ -28,5 +31,22 @@ public class ResequenceProperties {
 
     public TombstoneSortOrder getTombstoneSortOrder() {
         return tombstoneSortOrder;
+    }
+
+    public OtelProperties getOtel() {
+        return otel;
+    }
+
+    public static class OtelProperties {
+
+        private final boolean enabled;
+
+        public OtelProperties(Boolean enabled) {
+            this.enabled = enabled != null ? enabled : true;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
     }
 }

--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListener.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListener.java
@@ -1,0 +1,144 @@
+package com.snekse.kafka.streams.resequence.listener;
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * {@link ResequenceEventListener} implementation that emits metrics via the OpenTelemetry API.
+ *
+ * <p>All OTel instruments are created once in the constructor from the provided
+ * {@link OpenTelemetry} instance. In addition to OTel instruments, simple {@link AtomicLong}
+ * accumulators are maintained so that callers can read lifetime totals without needing access
+ * to an OTel {@code MetricReader}.
+ *
+ * <p>This class is safe to use with KStreams processors because Kafka Streams processor tasks
+ * are single-threaded. The plain {@code long} timing fields ({@code flushStartNanos},
+ * {@code lastFlushWasFullScan}) are not synchronized for this reason.
+ */
+public class OtelResequenceEventListener implements ResequenceEventListener {
+
+    private static final String INSTRUMENTATION_NAME = "com.snekse.kafka.streams.resequence";
+    private static final AttributeKey<Boolean> FULL_SCAN = AttributeKey.booleanKey("full_scan");
+
+    // OTel instruments
+    private final LongCounter recordsBuffered;
+    private final LongCounter tombstonesReceived;
+    private final LongCounter recordsIgnored;
+    private final LongCounter recordsForwarded;
+    private final LongCounter flushCount;
+    private final LongHistogram flushDurationMs;
+    private final LongHistogram bufferSize;
+
+    // Lifetime accumulators for shutdown summary logging (no MetricReader needed)
+    private final AtomicLong totalRecordsBuffered = new AtomicLong();
+    private final AtomicLong totalTombstonesReceived = new AtomicLong();
+    private final AtomicLong totalRecordsIgnored = new AtomicLong();
+    private final AtomicLong totalRecordsForwarded = new AtomicLong();
+    private final AtomicLong totalFlushes = new AtomicLong();
+
+    // Flush timing state — safe as plain fields because KStreams is single-threaded per task
+    private long flushStartNanos;
+    private boolean lastFlushWasFullScan;
+
+    public OtelResequenceEventListener(OpenTelemetry openTelemetry) {
+        Meter meter = openTelemetry.getMeter(INSTRUMENTATION_NAME);
+
+        recordsBuffered = meter.counterBuilder("resequence.records.buffered")
+                .setDescription("Number of records appended to the resequence buffer (includes tombstones)")
+                .setUnit("{record}")
+                .build();
+
+        tombstonesReceived = meter.counterBuilder("resequence.tombstones.received")
+                .setDescription("Number of tombstone (null-value) records buffered")
+                .setUnit("{record}")
+                .build();
+
+        recordsIgnored = meter.counterBuilder("resequence.records.ignored")
+                .setDescription("Number of records silently ignored due to null key")
+                .setUnit("{record}")
+                .build();
+
+        recordsForwarded = meter.counterBuilder("resequence.records.forwarded")
+                .setDescription("Number of records sorted and forwarded downstream")
+                .setUnit("{record}")
+                .build();
+
+        flushCount = meter.counterBuilder("resequence.flushes")
+                .setDescription("Number of flush cycles completed")
+                .setUnit("{flush}")
+                .build();
+
+        flushDurationMs = meter.histogramBuilder("resequence.flush.duration")
+                .ofLongs()
+                .setDescription("Duration of each flush cycle in milliseconds")
+                .setUnit("ms")
+                .build();
+
+        bufferSize = meter.histogramBuilder("resequence.buffer.size")
+                .ofLongs()
+                .setDescription("Number of records per key at flush time")
+                .setUnit("{record}")
+                .build();
+    }
+
+    @Override
+    public void onRecordBuffered(Object key, BufferedRecord<?> record) {
+        recordsBuffered.add(1);
+        totalRecordsBuffered.incrementAndGet();
+    }
+
+    @Override
+    public void onTombstoneReceived(Object key, BufferedRecord<?> record) {
+        tombstonesReceived.add(1);
+        totalTombstonesReceived.incrementAndGet();
+    }
+
+    @Override
+    public void onRecordIgnored() {
+        recordsIgnored.add(1);
+        totalRecordsIgnored.incrementAndGet();
+    }
+
+    @Override
+    public void onFlushStarted(boolean isFullScan) {
+        this.lastFlushWasFullScan = isFullScan;
+        this.flushStartNanos = System.nanoTime();
+    }
+
+    @Override
+    public void onFlushCompleted(int keysCount, int recordsCount) {
+        long durationMs = (System.nanoTime() - flushStartNanos) / 1_000_000;
+        flushDurationMs.record(durationMs);
+        flushCount.add(1, Attributes.of(FULL_SCAN, lastFlushWasFullScan));
+        totalRecordsForwarded.addAndGet(recordsCount);
+        totalFlushes.incrementAndGet();
+    }
+
+    @Override
+    public void onKeyFlushed(Object key, int recordCount) {
+        recordsForwarded.add(recordCount);
+        bufferSize.record(recordCount);
+    }
+
+    /** Returns the total number of records buffered since this listener was created. */
+    public long getTotalRecordsBuffered() { return totalRecordsBuffered.get(); }
+
+    /** Returns the total number of tombstone records buffered since this listener was created. */
+    public long getTotalTombstonesReceived() { return totalTombstonesReceived.get(); }
+
+    /** Returns the total number of records ignored (null key) since this listener was created. */
+    public long getTotalRecordsIgnored() { return totalRecordsIgnored.get(); }
+
+    /** Returns the total number of records forwarded downstream since this listener was created. */
+    public long getTotalRecordsForwarded() { return totalRecordsForwarded.get(); }
+
+    /** Returns the total number of flush cycles completed since this listener was created. */
+    public long getTotalFlushes() { return totalFlushes.get(); }
+}

--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/ResequenceEventListener.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/listener/ResequenceEventListener.java
@@ -1,0 +1,118 @@
+package com.snekse.kafka.streams.resequence.listener;
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
+
+/**
+ * Callback interface for observing significant events in a
+ * {@link com.snekse.kafka.streams.resequence.processor.ResequenceProcessor}.
+ *
+ * <p>Implementations can use this interface to collect metrics, emit telemetry, log diagnostic
+ * information, or trigger custom business logic in response to resequencing events. A no-op
+ * implementation is available via {@link #noOp()}.
+ *
+ * <p>Callback methods are invoked synchronously on the Kafka Streams processor thread.
+ * Because Kafka Streams tasks are single-threaded, implementations do not need to be
+ * thread-safe unless a single listener instance is shared across multiple processor instances.
+ *
+ * <p>Implementations should be lightweight and non-blocking. Expensive operations (e.g., remote
+ * calls) should be performed asynchronously to avoid introducing latency into the processing loop.
+ */
+public interface ResequenceEventListener {
+
+    /**
+     * Called when a record has been appended to the resequence buffer for the given key.
+     *
+     * <p>This callback fires after the record is successfully written to the state store.
+     * It is not called for records with null keys (see {@link #onRecordIgnored()}).
+     * For tombstone records (null value), this callback fires in addition to
+     * {@link #onTombstoneReceived(Object, BufferedRecord)}.
+     *
+     * @param key    the record's input key (before any key mapping)
+     * @param record the buffered record, including the original value and Kafka metadata
+     *               (partition, offset, timestamp)
+     */
+    void onRecordBuffered(Object key, BufferedRecord<?> record);
+
+    /**
+     * Called when an incoming record has a null value, indicating a tombstone.
+     *
+     * <p>This callback fires in addition to {@link #onRecordBuffered(Object, BufferedRecord)}
+     * when the record value is null. It fires before {@code onRecordBuffered} for the same
+     * record. Tombstones are valid domain events — they are buffered and forwarded downstream
+     * in sorted order according to the processor's
+     * {@link com.snekse.kafka.streams.resequence.domain.TombstoneSortOrder} configuration.
+     *
+     * <p>The {@code record} parameter will have a null {@code record} field
+     * ({@code bufferedRecord.getRecord() == null}) but will carry valid Kafka metadata
+     * (partition, offset, timestamp).
+     *
+     * @param key    the record's input key
+     * @param record the buffered tombstone record with Kafka metadata
+     */
+    void onTombstoneReceived(Object key, BufferedRecord<?> record);
+
+    /**
+     * Called at the beginning of each flush cycle, before any keys are processed.
+     *
+     * <p>This callback fires once per punctuator invocation. It is always followed by
+     * a corresponding {@link #onFlushCompleted(int, int)} call.
+     *
+     * @param isFullScan {@code true} on the first flush after startup or partition rebalance,
+     *                   when the processor performs a full state store scan to recover previously
+     *                   buffered records; {@code false} for all subsequent flushes, which use
+     *                   an efficient dirty-key lookup
+     */
+    void onFlushStarted(boolean isFullScan);
+
+    /**
+     * Called at the end of each flush cycle, after all dirty keys have been sorted, forwarded,
+     * and removed from the state store.
+     *
+     * <p>This callback fires once per punctuator invocation, after all
+     * {@link #onKeyFlushed(Object, int)} calls for this cycle have completed.
+     *
+     * @param keysCount    the number of distinct keys flushed in this cycle
+     * @param recordsCount the total number of records forwarded across all keys in this cycle
+     */
+    void onFlushCompleted(int keysCount, int recordsCount);
+
+    /**
+     * Called after a single key's buffered records have been sorted and forwarded downstream,
+     * and before the key's entry is deleted from the state store.
+     *
+     * <p>This callback fires once per distinct key per flush cycle. It is only called when
+     * the key has at least one buffered record; keys with null or empty record lists are skipped.
+     *
+     * @param key         the input key (before any key mapping applied by the processor)
+     * @param recordCount the number of records sorted and forwarded for this key
+     */
+    void onKeyFlushed(Object key, int recordCount);
+
+    /**
+     * Called when an incoming record is silently ignored because its key is null.
+     *
+     * <p>Null-key records cannot be stored in the Kafka Streams state store. The record
+     * is not buffered and will not appear in the output topic. This callback provides
+     * visibility into such data quality events.
+     */
+    void onRecordIgnored();
+
+    /**
+     * Returns a no-op implementation that does nothing for all callbacks.
+     *
+     * <p>This is the default listener used when no listener is explicitly provided to
+     * {@link com.snekse.kafka.streams.resequence.processor.ResequenceProcessor}.
+     *
+     * @return a stateless no-op {@code ResequenceEventListener}
+     */
+    static ResequenceEventListener noOp() {
+        return new ResequenceEventListener() {
+            public void onRecordBuffered(Object key, BufferedRecord<?> record) {}
+            public void onTombstoneReceived(Object key, BufferedRecord<?> record) {}
+            public void onFlushStarted(boolean isFullScan) {}
+            public void onFlushCompleted(int keysCount, int recordsCount) {}
+            public void onKeyFlushed(Object key, int recordCount) {}
+            public void onRecordIgnored() {}
+        };
+    }
+}

--- a/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/processor/ResequenceProcessor.java
+++ b/resequence-starter/src/main/java/com/snekse/kafka/streams/resequence/processor/ResequenceProcessor.java
@@ -2,6 +2,7 @@ package com.snekse.kafka.streams.resequence.processor;
 
 import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
 import com.snekse.kafka.streams.resequence.domain.ResequenceComparator;
+import com.snekse.kafka.streams.resequence.listener.ResequenceEventListener;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -68,23 +69,33 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
     private final Duration flushInterval;
     private final KeyMapper<K, KR> keyMapper;
     private final ValueMapper<KR, V, VR> valueMapper;
+    private final ResequenceEventListener listener;
     private final Set<K> dirtyKeys = new HashSet<>();
     private boolean needsRecoveryScan = true;
     private KeyValueStore<K, List<BufferedRecord<V>>> store;
 
     @SuppressWarnings({"unchecked", "unused"})
     public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval) {
-        this(comparator, stateStoreName, flushInterval, null, (ValueMapper<KR, V, VR>) ValueMapper.noOp());
+        this(comparator, stateStoreName, flushInterval, null,
+                (ValueMapper<KR, V, VR>) ValueMapper.noOp(), ResequenceEventListener.noOp());
     }
 
     @SuppressWarnings("unchecked")
     public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval,
                                KeyMapper<K, KR> keyMapper, ValueMapper<KR, V, VR> valueMapper) {
+        this(comparator, stateStoreName, flushInterval, keyMapper, valueMapper, ResequenceEventListener.noOp());
+    }
+
+    @SuppressWarnings("unchecked")
+    public ResequenceProcessor(ResequenceComparator<V> comparator, String stateStoreName, Duration flushInterval,
+                               KeyMapper<K, KR> keyMapper, ValueMapper<KR, V, VR> valueMapper,
+                               ResequenceEventListener listener) {
         this.comparator = comparator;
         this.stateStoreName = stateStoreName;
         this.flushInterval = flushInterval;
         this.keyMapper = keyMapper;
         this.valueMapper = valueMapper != null ? valueMapper : (ValueMapper<KR, V, VR>) ValueMapper.noOp();
+        this.listener = listener != null ? listener : ResequenceEventListener.noOp();
     }
 
     @Override
@@ -103,6 +114,7 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
 
         // Skip records with null keys to avoid NPE in state store operations
         if (key == null) {
+            listener.onRecordIgnored();
             return;
         }
 
@@ -122,6 +134,12 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
         records.add(buffered);
         store.put(key, records);
         dirtyKeys.add(key);
+
+        // Notify tombstone before the general buffered callback
+        if (value == null) {
+            listener.onTombstoneReceived(key, buffered);
+        }
+        listener.onRecordBuffered(key, buffered);
     }
 
     /**
@@ -130,24 +148,27 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
      * Clears {@code dirtyKeys} after either path completes.
      */
     private void flushAll(long timestamp) {
+        listener.onFlushStarted(needsRecoveryScan);
+        int[] totals = {0, 0}; // [keysCount, recordsCount]
         if (needsRecoveryScan) {
-            flushViaFullScan(timestamp);
+            flushViaFullScan(timestamp, totals);
             needsRecoveryScan = false;
         } else {
-            flushViaDirtyKeys(timestamp);
+            flushViaDirtyKeys(timestamp, totals);
         }
         dirtyKeys.clear();
+        listener.onFlushCompleted(totals[0], totals[1]);
     }
 
     /**
      * Scans the entire state store and flushes every key. Used once per task assignment to recover
      * records that were persisted before this processor instance was created.
      */
-    private void flushViaFullScan(long timestamp) {
+    private void flushViaFullScan(long timestamp, int[] totals) {
         try (KeyValueIterator<K, List<BufferedRecord<V>>> iter = store.all()) {
             while (iter.hasNext()) {
                 var entry = iter.next();
-                flushKey(entry.key, entry.value, timestamp);
+                flushKey(entry.key, entry.value, timestamp, totals);
             }
         }
     }
@@ -157,10 +178,10 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
      * lookups ({@code store.get}) rather than a full scan, keeping flush cost proportional to
      * write activity rather than total store size.
      */
-    private void flushViaDirtyKeys(long timestamp) {
+    private void flushViaDirtyKeys(long timestamp, int[] totals) {
         for (K key : dirtyKeys) {
             List<BufferedRecord<V>> records = store.get(key);
-            flushKey(key, records, timestamp);
+            flushKey(key, records, timestamp, totals);
         }
     }
 
@@ -169,7 +190,7 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
      * entry. No-ops if {@code records} is null or empty. Called by both flush paths.
      */
     @SuppressWarnings("unchecked")
-    private void flushKey(K key, List<BufferedRecord<V>> records, long timestamp) {
+    private void flushKey(K key, List<BufferedRecord<V>> records, long timestamp, int[] totals) {
         if (records == null || records.isEmpty()) {
             return;
         }
@@ -186,7 +207,13 @@ public class ResequenceProcessor<K, V, KR, VR> extends ContextualProcessor<K, V,
             context().forward(new Record<>(outputKey, mappedValue, timestamp));
         }
 
+        // Notify before deleting so the listener can still inspect the store if needed
+        listener.onKeyFlushed(key, records.size());
+
         // Clear the buffer for this key
         store.delete(key);
+
+        totals[0]++;
+        totals[1] += records.size();
     }
 }

--- a/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListenerSpec.groovy
+++ b/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/OtelResequenceEventListenerSpec.groovy
@@ -1,0 +1,265 @@
+package com.snekse.kafka.streams.resequence.listener
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord
+import com.snekse.kafka.streams.resequence.domain.ResequenceComparator
+import com.snekse.kafka.streams.resequence.domain.TombstoneSortOrder
+import com.snekse.kafka.streams.resequence.processor.ResequenceProcessor
+import com.snekse.kafka.streams.resequence.serde.BufferedRecordListSerde
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.data.LongPointData
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.TopologyTestDriver
+import org.apache.kafka.streams.state.Stores
+import org.springframework.kafka.support.serializer.JacksonJsonSerde
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import tools.jackson.databind.json.JsonMapper
+
+import java.time.Duration
+
+class OtelResequenceEventListenerSpec extends Specification {
+
+    static final String SOURCE_TOPIC = 'input'
+    static final String SINK_TOPIC = 'output'
+    static final String STATE_STORE = 'resequence-store'
+    static final Duration FLUSH_INTERVAL = Duration.ofMillis(100)
+
+    static class TestRecord {
+        String type
+        long ts
+
+        TestRecord() {}
+        TestRecord(String type, long ts) { this.type = type; this.ts = ts }
+    }
+
+    static final ResequenceComparator<TestRecord> TEST_COMPARATOR = { BufferedRecord<TestRecord> a, BufferedRecord<TestRecord> b ->
+        def r1 = a.record
+        def r2 = b.record
+        if (r1 == null && r2 == null) return 0
+        if (r1 == null) return TombstoneSortOrder.LAST.signum
+        if (r2 == null) return -TombstoneSortOrder.LAST.signum
+        Long.compare(r1.ts, r2.ts)
+    } as ResequenceComparator<TestRecord>
+
+    InMemoryMetricReader metricReader
+    OtelResequenceEventListener otelListener
+
+    @AutoCleanup
+    TopologyTestDriver driver
+
+    def setup() {
+        metricReader = InMemoryMetricReader.create()
+        def meterProvider = SdkMeterProvider.builder()
+                .registerMetricReader(metricReader)
+                .build()
+        def openTelemetry = OpenTelemetrySdk.builder()
+                .setMeterProvider(meterProvider)
+                .build()
+        otelListener = new OtelResequenceEventListener(openTelemetry)
+    }
+
+    private Topology buildTopology() {
+        def valueSerde = new JacksonJsonSerde<>(TestRecord)
+        def bufferedSerde = new BufferedRecordListSerde<>(TestRecord, JsonMapper.builder().build())
+        def topology = new Topology()
+        topology.addStateStore(Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(STATE_STORE), Serdes.String(), bufferedSerde))
+        topology.addSource('source', Serdes.String().deserializer(), valueSerde.deserializer(), SOURCE_TOPIC)
+        topology.addProcessor('resequencer',
+                () -> new ResequenceProcessor<>(TEST_COMPARATOR, STATE_STORE, FLUSH_INTERVAL, null, null, otelListener),
+                'source')
+        topology.connectProcessorAndStateStores('resequencer', STATE_STORE)
+        topology.addSink('sink', SINK_TOPIC, Serdes.String().serializer(), valueSerde.serializer(), 'resequencer')
+        topology
+    }
+
+    private static Properties driverConfig() {
+        def props = new Properties()
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, 'test-app')
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.name)
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.name)
+        props
+    }
+
+    /** Find the sum of all data points for a counter metric by name. */
+    private long counterValue(String metricName) {
+        Collection<MetricData> metrics = metricReader.collectAllMetrics()
+        def metric = metrics.find { it.name == metricName }
+        if (metric == null) return 0L
+        metric.longSumData.points.sum { LongPointData p -> p.value } as long
+    }
+
+    /** Find all data point values for a histogram metric by name. */
+    private List<Long> histogramCounts(String metricName) {
+        Collection<MetricData> metrics = metricReader.collectAllMetrics()
+        def metric = metrics.find { it.name == metricName }
+        if (metric == null) return []
+        metric.histogramData.points.collect { it.count } as List<Long>
+    }
+
+    def 'records.buffered counter increments for each non-tombstone record'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+        input.pipeInput('k1', new TestRecord('B', 2000L))
+        input.pipeInput('k2', new TestRecord('C', 3000L))
+
+        then:
+        counterValue('resequence.records.buffered') == 3
+        counterValue('resequence.tombstones.received') == 0
+    }
+
+    def 'tombstones.received and records.buffered both increment for null-value records'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        input.pipeInput('k1', null as TestRecord)
+
+        then:
+        counterValue('resequence.tombstones.received') == 1
+        counterValue('resequence.records.buffered') == 1
+    }
+
+    def 'records.ignored counter increments for null-key records; buffered stays zero'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        input.pipeInput(null as String, new TestRecord('A', 1000L))
+
+        then:
+        counterValue('resequence.records.ignored') == 1
+        counterValue('resequence.records.buffered') == 0
+    }
+
+    def 'flushes counter increments once per flush cycle; first flush has full_scan=true'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+
+        when: 'first flush'
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        def metrics = metricReader.collectAllMetrics()
+        def flushMetric = metrics.find { it.name == 'resequence.flushes' }
+        flushMetric != null
+        def points = flushMetric.longSumData.points
+        points.size() == 1
+        points[0].value == 1
+        points[0].attributes.get(AttributeKey.booleanKey('full_scan')) == true
+
+        when: 'second flush'
+        input.pipeInput('k1', new TestRecord('B', 2000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        def metrics2 = metricReader.collectAllMetrics()
+        def flushMetric2 = metrics2.find { it.name == 'resequence.flushes' }
+        def byFullScan = flushMetric2.longSumData.points.groupBy {
+            it.attributes.get(AttributeKey.booleanKey('full_scan'))
+        }
+        byFullScan[true][0].value == 1
+        byFullScan[false][0].value == 1
+    }
+
+    def 'flush.duration histogram records one entry per flush'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+
+        when:
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        def counts = histogramCounts('resequence.flush.duration')
+        counts.size() == 1
+        counts[0] == 1  // one data point recorded for this flush
+    }
+
+    def 'buffer.size histogram records per-key record count at flush time'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when: '3 records buffered under same key, then flushed'
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+        input.pipeInput('k1', new TestRecord('B', 2000L))
+        input.pipeInput('k1', new TestRecord('C', 3000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        def metrics = metricReader.collectAllMetrics()
+        def bufferMetric = metrics.find { it.name == 'resequence.buffer.size' }
+        bufferMetric != null
+        def point = bufferMetric.histogramData.points[0]
+        point.sum == 3  // one key flushed with 3 records → sum == 3
+    }
+
+    def 'records.forwarded counter equals records buffered after flush'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+        input.pipeInput('k2', new TestRecord('B', 2000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        counterValue('resequence.records.forwarded') == 2
+    }
+
+    def 'accumulator getters match OTel counter values'() {
+        given:
+        driver = new TopologyTestDriver(buildTopology(), driverConfig())
+        def input = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        input.pipeInput('k1', new TestRecord('A', 1000L))
+        input.pipeInput('k1', null as TestRecord)          // tombstone
+        input.pipeInput(null as String, new TestRecord('B', 2000L))  // ignored
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        otelListener.totalRecordsBuffered == counterValue('resequence.records.buffered')
+        otelListener.totalTombstonesReceived == counterValue('resequence.tombstones.received')
+        otelListener.totalRecordsIgnored == counterValue('resequence.records.ignored')
+        otelListener.totalRecordsForwarded == counterValue('resequence.records.forwarded')
+        otelListener.totalFlushes == 1
+    }
+
+    def 'OtelResequenceEventListener constructed with GlobalOpenTelemetry noop does not throw'() {
+        when: 'use the noop GlobalOpenTelemetry (no SDK on classpath needed)'
+        def noopListener = new OtelResequenceEventListener(GlobalOpenTelemetry.get())
+        noopListener.onRecordIgnored()
+        noopListener.onFlushStarted(true)
+        noopListener.onFlushCompleted(0, 0)
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/ResequenceEventListenerSpec.groovy
+++ b/resequence-starter/src/test/groovy/com/snekse/kafka/streams/resequence/listener/ResequenceEventListenerSpec.groovy
@@ -1,0 +1,236 @@
+package com.snekse.kafka.streams.resequence.listener
+
+import com.snekse.kafka.streams.resequence.domain.BufferedRecord
+import com.snekse.kafka.streams.resequence.domain.ResequenceComparator
+import com.snekse.kafka.streams.resequence.domain.TombstoneSortOrder
+import com.snekse.kafka.streams.resequence.processor.KeyMapper
+import com.snekse.kafka.streams.resequence.processor.ResequenceProcessor
+import com.snekse.kafka.streams.resequence.processor.ValueMapper
+import com.snekse.kafka.streams.resequence.serde.BufferedRecordListSerde
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.TopologyTestDriver
+import org.apache.kafka.streams.state.Stores
+import org.springframework.kafka.support.serializer.JacksonJsonSerde
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import tools.jackson.databind.json.JsonMapper
+
+import java.time.Duration
+
+class ResequenceEventListenerSpec extends Specification {
+
+    static final String SOURCE_TOPIC = 'input'
+    static final String SINK_TOPIC = 'output'
+    static final String STATE_STORE = 'resequence-store'
+    static final Duration FLUSH_INTERVAL = Duration.ofMillis(100)
+
+    static class TestRecord {
+        String type
+        long ts
+
+        TestRecord() {}
+        TestRecord(String type, long ts) { this.type = type; this.ts = ts }
+    }
+
+    static final ResequenceComparator<TestRecord> TEST_COMPARATOR = { BufferedRecord<TestRecord> a, BufferedRecord<TestRecord> b ->
+        def r1 = a.record
+        def r2 = b.record
+        if (r1 == null && r2 == null) return 0
+        if (r1 == null) return TombstoneSortOrder.LAST.signum
+        if (r2 == null) return -TombstoneSortOrder.LAST.signum
+        Long.compare(r1.ts, r2.ts)
+    } as ResequenceComparator<TestRecord>
+
+    @AutoCleanup
+    TopologyTestDriver driver
+
+    private static Properties driverConfig() {
+        def props = new Properties()
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, 'test-app')
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.name)
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.name)
+        props
+    }
+
+    private static Topology buildTopology(ResequenceEventListener listener) {
+        def valueSerde = new JacksonJsonSerde<>(TestRecord)
+        def bufferedSerde = new BufferedRecordListSerde<>(TestRecord, JsonMapper.builder().build())
+
+        def topology = new Topology()
+        topology.addStateStore(Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(STATE_STORE),
+                Serdes.String(),
+                bufferedSerde))
+
+        topology.addSource('source',
+                Serdes.String().deserializer(),
+                valueSerde.deserializer(),
+                SOURCE_TOPIC)
+
+        topology.addProcessor('resequencer',
+                () -> new ResequenceProcessor<>(TEST_COMPARATOR, STATE_STORE, FLUSH_INTERVAL, null, null, listener),
+                'source')
+
+        topology.connectProcessorAndStateStores('resequencer', STATE_STORE)
+
+        topology.addSink('sink',
+                SINK_TOPIC,
+                Serdes.String().serializer(),
+                valueSerde.serializer(),
+                'resequencer')
+
+        topology
+    }
+
+    def 'onRecordIgnored fires once for a null-key record and nothing is buffered or output'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+        def outputTopic = driver.createOutputTopic(SINK_TOPIC,
+                Serdes.String().deserializer(), new JacksonJsonSerde<>(TestRecord).deserializer())
+
+        when:
+        inputTopic.pipeInput(null as String, new TestRecord('A', 1000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onRecordIgnored()
+        0 * listener.onRecordBuffered(_, _)
+        0 * listener.onTombstoneReceived(_, _)
+        outputTopic.readKeyValuesToList().isEmpty()
+    }
+
+    def 'onRecordBuffered fires for a normal (non-null-value) record'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+
+        then:
+        1 * listener.onRecordBuffered('key1', { BufferedRecord br -> br.record != null })
+        0 * listener.onTombstoneReceived(_, _)
+        0 * listener.onRecordIgnored()
+    }
+
+    def 'both onTombstoneReceived and onRecordBuffered fire for a tombstone record'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        inputTopic.pipeInput('key1', null as TestRecord)
+
+        then: 'tombstone fires first, then general buffered callback'
+        1 * listener.onTombstoneReceived('key1', { BufferedRecord br -> br.record == null })
+        1 * listener.onRecordBuffered('key1', { BufferedRecord br -> br.record == null })
+        0 * listener.onRecordIgnored()
+    }
+
+    def 'onFlushStarted fires with isFullScan=true on first flush, false on subsequent flushes'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+
+        when: 'first flush'
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onFlushStarted(true)
+
+        when: 'second flush'
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onFlushStarted(false)
+    }
+
+    def 'onKeyFlushed fires once per distinct key with correct record count'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+        inputTopic.pipeInput('key1', new TestRecord('B', 2000L))
+        inputTopic.pipeInput('key2', new TestRecord('C', 3000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onKeyFlushed('key1', 2)
+        1 * listener.onKeyFlushed('key2', 1)
+    }
+
+    def 'onFlushCompleted fires once per flush with accurate keysCount and recordsCount'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when:
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+        inputTopic.pipeInput('key1', new TestRecord('B', 2000L))
+        inputTopic.pipeInput('key2', new TestRecord('C', 3000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onFlushCompleted(2, 3)
+    }
+
+    def 'onFlushCompleted reports zero totals when no records arrived between flushes'() {
+        given:
+        ResequenceEventListener listener = Mock()
+        driver = new TopologyTestDriver(buildTopology(listener), driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+
+        when: 'first flush with one record'
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onFlushCompleted(1, 1)
+
+        when: 'second flush with no new records'
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        1 * listener.onFlushCompleted(0, 0)
+    }
+
+    def 'noOp listener causes no regressions — existing processor behaviour is unchanged'() {
+        given:
+        def topology = buildTopology(ResequenceEventListener.noOp())
+        driver = new TopologyTestDriver(topology, driverConfig())
+        def inputTopic = driver.createInputTopic(SOURCE_TOPIC,
+                Serdes.String().serializer(), new JacksonJsonSerde<>(TestRecord).serializer())
+        def outputTopic = driver.createOutputTopic(SINK_TOPIC,
+                Serdes.String().deserializer(), new JacksonJsonSerde<>(TestRecord).deserializer())
+
+        when:
+        inputTopic.pipeInput('key1', new TestRecord('B', 2000L))
+        inputTopic.pipeInput('key1', new TestRecord('A', 1000L))
+        driver.advanceWallClockTime(FLUSH_INTERVAL)
+
+        then:
+        def results = outputTopic.readKeyValuesToList()
+        results.size() == 2
+        results[0].value.type == 'A'
+        results[1].value.type == 'B'
+    }
+}

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -13,6 +13,11 @@ implementation("org.springframework.boot:spring-boot-starter-kafka")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
+    // OTel SDK for runtime metric emission
+    implementation("io.opentelemetry:opentelemetry-api")
+    implementation("io.opentelemetry:opentelemetry-sdk")
+    implementation("io.opentelemetry:opentelemetry-exporter-logging")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.apache.kafka:kafka-streams-test-utils")

--- a/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
+++ b/sample-app/src/main/java/com/example/sampleapp/config/ResequenceTopologyConfig.java
@@ -6,6 +6,7 @@ import com.snekse.kafka.streams.resequence.config.ResequenceProperties;
 import com.snekse.kafka.streams.resequence.domain.BufferedRecord;
 import com.snekse.kafka.streams.resequence.domain.ResequenceComparator;
 import com.snekse.kafka.streams.resequence.processor.KeyMapper;
+import com.snekse.kafka.streams.resequence.listener.ResequenceEventListener;
 import com.snekse.kafka.streams.resequence.processor.ResequenceProcessor;
 import com.snekse.kafka.streams.resequence.processor.ValueMapper;
 import com.snekse.kafka.streams.resequence.serde.BufferedRecordListSerde;
@@ -52,7 +53,8 @@ public class ResequenceTopologyConfig {
             StreamsBuilder builder,
             Serde<SampleRecord> sampleRecordSerde,
             Serde<List<BufferedRecord<SampleRecord>>> bufferedRecordListSerde,
-            ResequenceComparator<SampleRecord> resequenceComparator) {
+            ResequenceComparator<SampleRecord> resequenceComparator,
+            ResequenceEventListener listener) {
 
         String stateStoreName = resequenceProperties.getStateStoreName();
         Topology topology = builder.build();
@@ -83,7 +85,7 @@ public class ResequenceTopologyConfig {
 
         // Add processor with injected comparator, state store name, and flush interval
         topology.addProcessor("resequencer",
-                () -> new ResequenceProcessor<>(resequenceComparator, stateStoreName, resequenceProperties.getFlushInterval(), keyMapper, valueMapper),
+                () -> new ResequenceProcessor<>(resequenceComparator, stateStoreName, resequenceProperties.getFlushInterval(), keyMapper, valueMapper, listener),
                 "source");
 
         // Connect state store to processor

--- a/sample-app/src/main/java/com/example/sampleapp/observability/MetricsShutdownLogger.java
+++ b/sample-app/src/main/java/com/example/sampleapp/observability/MetricsShutdownLogger.java
@@ -1,0 +1,38 @@
+package com.example.sampleapp.observability;
+
+import com.snekse.kafka.streams.resequence.listener.OtelResequenceEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs a one-line resequencer metrics summary to the console when the application shuts down.
+ *
+ * <p>Only active when an {@link OtelResequenceEventListener} bean is present (i.e., OTel
+ * is on the classpath and {@code resequence.otel.enabled} is not {@code false}).
+ */
+@Component
+@ConditionalOnBean(OtelResequenceEventListener.class)
+public class MetricsShutdownLogger implements ApplicationListener<ContextClosedEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsShutdownLogger.class);
+
+    private final OtelResequenceEventListener listener;
+
+    public MetricsShutdownLogger(OtelResequenceEventListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        log.info("Resequencer metrics summary — buffered={} tombstones={} ignored={} forwarded={} flushes={}",
+                listener.getTotalRecordsBuffered(),
+                listener.getTotalTombstonesReceived(),
+                listener.getTotalRecordsIgnored(),
+                listener.getTotalRecordsForwarded(),
+                listener.getTotalFlushes());
+    }
+}

--- a/sample-app/src/main/java/com/example/sampleapp/observability/OtelConfig.java
+++ b/sample-app/src/main/java/com/example/sampleapp/observability/OtelConfig.java
@@ -1,0 +1,40 @@
+package com.example.sampleapp.observability;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Provides an {@link OpenTelemetry} bean backed by the OTel SDK with a logging metric exporter.
+ *
+ * <p>This configuration satisfies the {@code OpenTelemetry} dependency required by
+ * {@link com.snekse.kafka.streams.resequence.config.ResequenceAutoConfiguration} when
+ * OTel is on the classpath. Metrics are exported to the application log every 60 seconds
+ * via {@link LoggingMetricExporter}.
+ *
+ * <p>In production, replace this with your preferred OTel SDK setup
+ * (e.g., OTLP exporter, Prometheus exporter, or the OpenTelemetry Spring Boot Starter).
+ */
+@Configuration
+public class OtelConfig {
+
+    @Bean
+    public OpenTelemetry openTelemetry() {
+        SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+                .registerMetricReader(
+                        PeriodicMetricReader.builder(LoggingMetricExporter.create())
+                                .setInterval(Duration.ofSeconds(60))
+                                .build())
+                .build();
+
+        return OpenTelemetrySdk.builder()
+                .setMeterProvider(meterProvider)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `ResequenceEventListener` interface to `resequence-starter` with 6 callbacks (`onRecordBuffered`, `onTombstoneReceived`, `onRecordIgnored`, `onFlushStarted`, `onKeyFlushed`, `onFlushCompleted`) and a `noOp()` default — lets users plug in any observability backend without mandatory dependencies
- Adds `OtelResequenceEventListener` backed by OpenTelemetry API (`compileOnly`) — emits counters, histograms, and accumulators; auto-configured via Spring Boot when OTel API is on the classpath, opt-out via `resequence.otel.enabled=false`
- Updates `sample-app` to wire the listener into the topology, configure an OTel SDK bean with `LoggingMetricExporter`, and log a metrics summary on shutdown

## Metrics emitted
- `resequence.records.buffered` — counter
- `resequence.tombstones.received` — counter
- `resequence.records.ignored` — counter
- `resequence.records.forwarded` — counter
- `resequence.flushes` — counter with `full_scan` boolean attribute
- `resequence.flush.duration` — histogram (ms)
- `resequence.buffer.size` — histogram (records per key per flush)

## Test plan
- [ ] `./gradlew :resequence-starter:test` — all listener and OTel specs pass
- [ ] `./gradlew :resequence-starter:jar && jar tf resequence-starter/build/libs/*.jar | grep opentelemetry` — should return nothing (OTel not bundled)
- [ ] `./gradlew clean build` — full build passes (excluding pre-existing `BufferedRecordListSerdeSpec` failure)
- [ ] `./gradlew :sample-app:bootRun` — app starts and logs OTel metrics summary on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)